### PR TITLE
Switch stage automatically

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,6 @@
     <h2>Basic map</h2>
     <div
       class="geolonia"
-      data-key="YOUR-API-KEY"
       data-lat="35.681236"
       data-lng="139.767125"
       data-zoom="16"
@@ -29,7 +28,6 @@
     <h2>Zero configuration</h2>
     <div
       class="geolonia"
-      data-key="YOUR-API-KEY"
     ></div>
   </div>
 
@@ -37,7 +35,6 @@
     <h2>All of controls</h2>
     <div
       class="geolonia"
-      data-key="YOUR-API-KEY"
       data-lat="34.704395"
       data-lng="135.494771"
       data-zoom="14"
@@ -52,7 +49,6 @@
     <h2>Without controls</h2>
     <div
       class="geolonia"
-      data-key="YOUR-API-KEY"
       data-navigation-control="off"
       data-geolocate-control="off"
       data-lat="35.681236"
@@ -65,7 +61,6 @@
     <h2>Update hash</h2>
     <div
       class="geolonia"
-      data-key="YOUR-API-KEY"
       data-lat="35.681236"
       data-lng="139.767125"
       data-zoom="12"
@@ -77,7 +72,6 @@
     <h2>Specify the style</h2>
     <div
       class="geolonia"
-      data-key="YOUR-API-KEY"
       data-style="geolonia/midnight"
       data-lat="35.681236"
       data-lng="139.767125"
@@ -89,7 +83,6 @@
     <h2>Marker with Popup</h2>
     <div
       class="geolonia"
-      data-key="YOUR-API-KEY"
       data-lat="35.681236"
       data-lng="139.767125"
       data-zoom="12"
@@ -100,7 +93,6 @@
     <h2>Pitch and Bearing</h2>
     <div
       class="geolonia"
-      data-key="YOUR-API-KEY"
       data-lat="35.681236"
       data-lng="139.767125"
       data-zoom="12"
@@ -131,7 +123,6 @@
     <h3>HTML for the Map</h3>
     <div
       class="geolonia"
-      data-key="YOUR-API-KEY"
       data-lat="35.681236"
       data-lng="139.767125"
       data-zoom="12"
@@ -146,7 +137,6 @@
     <h2>Custom with JavaScript</h2>
     <div
       id="my-map"
-      data-key="YOUR-API-KEY"
       data-lat="35.681236"
       data-lng="139.767125"
       data-zoom="9"
@@ -327,7 +317,6 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
     </script>
     <div
       class="geolonia"
-      data-key="YOUR-API-KEY"
       data-geojson="#example-geojson"
       data-marker="off"
     ></div>
@@ -337,7 +326,6 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
     <h2>GeoJSON (Ajax) with SimpleStyle</h2>
     <div
       class="geolonia"
-      data-key="YOUR-API-KEY"
       data-lat="33.897"
       data-lng="135.639"
       data-zoom="10"
@@ -350,7 +338,6 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
     <h2>i18n</h2>
     <div
       class="geolonia"
-      data-key="YOUR-API-KEY"
       data-lat="33.897"
       data-lng="135.639"
       data-zoom="8"
@@ -362,7 +349,6 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
     <h2>Custom style</h2>
     <div
       class="geolonia"
-      data-key="YOUR-API-KEY"
       data-lat="33.897"
       data-lng="135.639"
       data-zoom="8"
@@ -374,7 +360,6 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
     <h2>Custom style with relative path</h2>
     <div
       class="geolonia"
-      data-key="YOUR-API-KEY"
       data-lat="33.897"
       data-lng="135.639"
       data-zoom="8"

--- a/docs/index.html
+++ b/docs/index.html
@@ -400,7 +400,6 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
   <a class="forkme" href="https://github.com/geolonia/embed"><img width="149" height="149" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png?resize=149%2C149" class="attachment-full size-full" alt="Fork me on GitHub" data-recalc-dims="1"></a>
 
   <script src="./embed.js"></script>
-  <script src="./geolonia-fork-me-plugin.min.js"></script>
   <script>
     var myMap = new geolonia.Map(document.querySelector('#my-map'));
     setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);

--- a/src/embed.js
+++ b/src/embed.js
@@ -55,5 +55,5 @@ if ( window === window.parent ) {
 
   window.mapboxgl = mapboxgl
 } else {
-  console.error( '[Geolonia] We are very sorry, but we can\'t display our map in iframe.' ) // eslint-disbale-line
+  console.error( '[Geolonia] We are very sorry, but we can\'t display our map in iframe.' ) // eslint-disable-line
 }

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -8,7 +8,7 @@ import parseAtts from './parse-atts'
 
 import * as util from './util'
 
-const getStyleURL = (styleName, userKey, stage = 'v1', lang = '') => {
+const getStyleURL = (styleName, userKey, stage = 'dev', lang = '') => {
   if ('en' === lang) {
     return `https://api.geolonia.com/${stage}/styles/${styleName}?key=${userKey}&lang=en`
   } else {
@@ -43,9 +43,9 @@ export default class GeoloniaMap extends mapboxgl.Map {
 
     let style = util.isURL(atts.style)
     if (!style) {
-      style = getStyleURL(atts.style, atts.key, 'v1')
+      style = getStyleURL(atts.style, atts.key, atts.stage)
       if (!lang.match(/^ja/i)) {
-        style = getStyleURL(atts.style, atts.key, 'v1', 'en')
+        style = getStyleURL(atts.style, atts.key, atts.stage, 'en')
       }
     }
 

--- a/src/lib/parse-api-key.js
+++ b/src/lib/parse-api-key.js
@@ -15,7 +15,7 @@ export default document => {
     if (q['geolonia-api-key'] || q['tilecloud-api-key']) {
       params.key = q['geolonia-api-key'] || q['tilecloud-api-key'] || 'YOUR-API-KEY'
 
-      const res = pathname.match( /^\/(v[0-9\.]+)\/embed/ )
+      const res = pathname.match( /^\/(v[0-9.]+)\/embed/ )
       if (res) {
         params.stage = res[1]
       }

--- a/src/lib/parse-api-key.js
+++ b/src/lib/parse-api-key.js
@@ -13,8 +13,12 @@ export default document => {
     const q = querystring.parse(query.replace(/^\?/, ''))
 
     if (q['geolonia-api-key'] || q['tilecloud-api-key']) {
-      params.key = q['geolonia-api-key'] || q['tilecloud-api-key'] || 'YOUR-API-KEY',
-      params.stage = (pathname.match( /^\/v1/ )) ? 'v1' : 'dev'
+      params.key = q['geolonia-api-key'] || q['tilecloud-api-key'] || 'YOUR-API-KEY'
+
+      const res = pathname.match( /^\/(v[0-9\.]+)\/embed/ )
+      if (res) {
+        params.stage = res[1]
+      }
 
       break
     }

--- a/src/lib/parse-api-key.js
+++ b/src/lib/parse-api-key.js
@@ -4,8 +4,8 @@ import querystring from 'querystring'
 export default document => {
   const scripts = document.getElementsByTagName('script')
   const params = {
-    key: "YOUR-API-KEY",
-    stage: "dev"
+    key: 'YOUR-API-KEY',
+    stage: 'dev',
   }
 
   for (const script of scripts) {
@@ -13,10 +13,10 @@ export default document => {
     const q = querystring.parse(query.replace(/^\?/, ''))
 
     if (q['geolonia-api-key'] || q['tilecloud-api-key']) {
-      params.key = q['geolonia-api-key'] || q['tilecloud-api-key'] || "YOUR-API-KEY",
+      params.key = q['geolonia-api-key'] || q['tilecloud-api-key'] || 'YOUR-API-KEY',
       params.stage = (pathname.match( /^\/v1/ )) ? 'v1' : 'dev'
 
-      break;
+      break
     }
   }
 

--- a/src/lib/parse-api-key.js
+++ b/src/lib/parse-api-key.js
@@ -3,15 +3,22 @@ import querystring from 'querystring'
 
 export default document => {
   const scripts = document.getElementsByTagName('script')
+  const params = {
+    key: "YOUR-API-KEY",
+    stage: "dev"
+  }
+
   for (const script of scripts) {
-    const { query } = urlParse(script.src)
+    const { pathname, query } = urlParse(script.src)
     const q = querystring.parse(query.replace(/^\?/, ''))
-    if (q['geolonia-api-key']) {
-      return q['geolonia-api-key']
-    } else if (q['tilecloud-api-key']) { // For backward compatibility
-      return q['tilecloud-api-key']
+
+    if (q['geolonia-api-key'] || q['tilecloud-api-key']) {
+      params.key = q['geolonia-api-key'] || q['tilecloud-api-key'] || "YOUR-API-KEY",
+      params.stage = (pathname.match( /^\/v1/ )) ? 'v1' : 'dev'
+
+      break;
     }
   }
 
-  return null
+  return params
 }

--- a/src/lib/parse-api-key.test.js
+++ b/src/lib/parse-api-key.test.js
@@ -8,8 +8,9 @@ describe('parse api key from dom', () => {
       <script src="https://external.example.com/?geolonia-api-key=abc"></script>
     </body></html>`).window
 
-    const apiKey = parseApiKey(mocDocument)
-    assert.deepEqual('abc', apiKey)
+    const params = parseApiKey(mocDocument)
+    assert.deepEqual('abc', params.key)
+    assert.deepEqual('dev', params.stage)
   })
 
   it('should parse with geolonia flag', () => {
@@ -18,8 +19,9 @@ describe('parse api key from dom', () => {
       <script src="https://external.example.com/?geolonia-api-key=def"></script>
     </body></html>`).window
 
-    const apiKey = parseApiKey(mocDocument)
-    assert.deepEqual('def', apiKey)
+    const params = parseApiKey(mocDocument)
+    assert.deepEqual('def', params.key)
+    assert.deepEqual('dev', params.stage)
   })
 
   it('should parse with tilecloud flag', () => {
@@ -27,8 +29,9 @@ describe('parse api key from dom', () => {
       <script src="https://external.example.com/?tilecloud-api-key=abc"></script>
     </body></html>`).window
 
-    const apiKey = parseApiKey(mocDocument)
-    assert.deepEqual('abc', apiKey)
+    const params = parseApiKey(mocDocument)
+    assert.deepEqual('abc', params.key)
+    assert.deepEqual('dev', params.stage)
   })
 
   it('should parse with tilecloud flag', () => {
@@ -37,7 +40,30 @@ describe('parse api key from dom', () => {
       <script src="https://external.example.com/?tilecloud-api-key=def"></script>
     </body></html>`).window
 
-    const apiKey = parseApiKey(mocDocument)
-    assert.deepEqual('def', apiKey)
+    const params = parseApiKey(mocDocument)
+    assert.deepEqual('def', params.key)
+    assert.deepEqual('dev', params.stage)
+  })
+
+  it('should be "YOUR-API-KEY" and "dev"', () => {
+    const { document: mocDocument } = new JSDOM(`<html><body>
+      <script src="https://external.example.com/jquery.js"></script>
+      <script type="text/javascript" src="https://api.geolonia.com/dev/embed?geolonia-api-key=YOUR-API-KEY"></script>
+    </body></html>`).window
+
+    const params = parseApiKey(mocDocument)
+    assert.deepEqual('YOUR-API-KEY', params.key)
+    assert.deepEqual('dev', params.stage)
+  })
+
+  it('should be "YOUR-API-KEY" and "v1"', () => {
+    const { document: mocDocument } = new JSDOM(`<html><body>
+      <script src="https://external.example.com/jquery.js"></script>
+      <script type="text/javascript" src="https://api.geolonia.com/v1/embed?geolonia-api-key=YOUR-API-KEY"></script>
+    </body></html>`).window
+
+    const params = parseApiKey(mocDocument)
+    assert.deepEqual('YOUR-API-KEY', params.key)
+    assert.deepEqual('v1', params.stage)
   })
 })

--- a/src/lib/parse-api-key.test.js
+++ b/src/lib/parse-api-key.test.js
@@ -66,4 +66,15 @@ describe('parse api key from dom', () => {
     assert.deepEqual('YOUR-API-KEY', params.key)
     assert.deepEqual('v1', params.stage)
   })
+
+  it('should be "YOUR-API-KEY" and "v123.4"', () => {
+    const { document: mocDocument } = new JSDOM(`<html><body>
+      <script src="https://external.example.com/jquery.js"></script>
+      <script type="text/javascript" src="https://api.geolonia.com/v123.4/embed?geolonia-api-key=YOUR-API-KEY"></script>
+    </body></html>`).window
+
+    const params = parseApiKey(mocDocument)
+    assert.deepEqual('YOUR-API-KEY', params.key)
+    assert.deepEqual('v123.4', params.stage)
+  })
 })

--- a/src/lib/parse-atts.js
+++ b/src/lib/parse-atts.js
@@ -7,6 +7,8 @@ export default container => {
     container.dataset = {}
   }
 
+  const params = parseApiKey(document)
+
   return {
     lat: 0,
     lng: 0,
@@ -28,7 +30,8 @@ export default container => {
     style: 'geolonia/basic',
     lang: 'auto',
     plugin: 'off',
-    key: parseApiKey(document),
+    key: params.key,
+    stage: params.stage,
     ...container.dataset,
   }
 }


### PR DESCRIPTION
API のステージを自動判別して切り替える。

* Embed API が `/^\/(v[0-9\.]+)\/embed/` という正規表現にマッチする URL でロードされた場合は、`v1234` のようなステージ名を使用する。 `/v1/embed` の場合は `v1`。
* 上の正規表現にマッチしない場合は、`dev`
* Embed API の HTML で `data-stage` 属性によってステージを指定された場合はその値を使用する。