### PR TITLE
Fix language handling

### DIFF
--- a/src/lib/mbgl-gesture-handling.js
+++ b/src/lib/mbgl-gesture-handling.js
@@ -11,7 +11,7 @@ class GestureHandling {
 
     let textMessage = 'Use alt + scroll to zoom the map.'
     let textMessageMobile = 'Use two fingers to move the map.'
-    const lang = options.lang || util.getLang()
+    const lang = (options.lang === 'auto' || !options.lang) ? util.getLang() : options.lang
     if ('ja' === lang) {
       textMessage = 'Alt キーを押しながらスクロールしてください。'
       textMessageMobile = '2本指を使って操作してください。'


### PR DESCRIPTION
Use browser language when `data-lang="auto"` specified.