### PR TITLE
Disables gesture handling if the document isn't scrollable

### DIFF
--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -63,7 +63,7 @@ export default class GeoloniaMap extends mapboxgl.Map {
 
     map.addControl(new GeoloniaControl())
 
-    if ('on' === atts.gestureHandling) {
+    if ('on' === atts.gestureHandling && util.isScrollable()) {
       new GestureHandling({ lang: atts.lang }).addTo(map)
     }
 

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -81,7 +81,7 @@ export function getLang() {
  * Detects the window is scrollable.
  */
 export function isScrollable() {
-  const {height: bodyHeight} = document.body.getBoundingClientRect()
+  const { height: bodyHeight } = document.body.getBoundingClientRect()
   const windowHeight = window.innerHeight
 
   if (bodyHeight > windowHeight) {

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -76,3 +76,17 @@ export function getLang() {
     return 'en'
   }
 }
+
+/**
+ * Detects the window is scrollable.
+ */
+export function isScrollable() {
+  const {height: bodyHeight} = document.body.getBoundingClientRect()
+  const windowHeight = window.innerHeight
+
+  if (bodyHeight > windowHeight) {
+    return true
+  } else {
+    return false
+  }
+}


### PR DESCRIPTION
Added function `isScrollable()` to detect the document is scrollable and disables if the function return false.