### PR TITLE
fixed #123

### DIFF
--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -52,7 +52,7 @@ export default class GeoloniaMap extends mapboxgl.Map {
     delete params.container // Don't overwrite container.
 
     const options = {
-      style: atts.style || params.style,
+      style: atts.style || params.style, // Validation for value of `style` will be processed on `setStyle()`.
       container,
       center: [parseFloat(atts.lng), parseFloat(atts.lat)],
       bearing: parseFloat(atts.bearing),
@@ -181,6 +181,8 @@ export default class GeoloniaMap extends mapboxgl.Map {
   }
 
   setStyle(style, options = {}) {
+    // It can't access `this` because `setStyle()` will be called with `super()`.
+    // So, we need to run `parseAtts()` again(?)
     const atts = parseAtts(this.getContainer())
     style = getStyleURL(style, atts)
 

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -8,11 +8,16 @@ import parseAtts from './parse-atts'
 
 import * as util from './util'
 
-const getStyleURL = (styleName, userKey, stage = 'dev', lang = '') => {
-  if ('en' === lang) {
-    return `https://api.geolonia.com/${stage}/styles/${styleName}?key=${userKey}&lang=en`
+const getStyleURL = (style, atts) => {
+  const styleUrl = util.isURL(style)
+  if (styleUrl) {
+    return styleUrl
   } else {
-    return `https://api.geolonia.com/${stage}/styles/${styleName}?key=${userKey}`
+    if ('en' === atts.lang) {
+      return `https://api.geolonia.com/${atts.stage}/styles/${style}?key=${atts.key}&lang=en`
+    } else {
+      return `https://api.geolonia.com/${atts.stage}/styles/${style}?key=${atts.key}`
+    }
   }
 }
 
@@ -44,27 +49,10 @@ export default class GeoloniaMap extends mapboxgl.Map {
     const container = util.getContainer(params)
     const atts = parseAtts(container)
 
-    let lang = 'atuo'
-    if ('auto' === atts.lang) {
-      lang = util.getLang()
-    } else if ('ja' === atts.lang) {
-      lang = 'ja'
-    } else {
-      lang = 'en'
-    }
-
-    let style = atts.style || params.style
-    if (!util.isURL(style)) {
-      style = getStyleURL(atts.style, atts.key, atts.stage)
-      if ('ja' !== lang) {
-        style = getStyleURL(atts.style, atts.key, atts.stage, 'en')
-      }
-    }
-
     delete params.container // Don't overwrite container.
 
     const options = {
-      style,
+      style: atts.style || params.style,
       container,
       center: [parseFloat(atts.lng), parseFloat(atts.lat)],
       bearing: parseFloat(atts.bearing),
@@ -190,5 +178,14 @@ export default class GeoloniaMap extends mapboxgl.Map {
     })
 
     return map
+  }
+
+  setStyle(style, options = {}) {
+    const atts = parseAtts(this.getContainer())
+    style = getStyleURL(style, atts)
+
+    // Calls `mapboxgl.Map.setStyle()`.
+    const parent = Object.getPrototypeOf(this)
+    parent.__proto__.setStyle.call(this, style, options)
   }
 }

--- a/src/lib/parse-atts.js
+++ b/src/lib/parse-atts.js
@@ -1,6 +1,7 @@
 'use strict'
 
 import parseApiKey from './parse-api-key'
+import * as util from './util'
 
 export default container => {
   if (!container.dataset) {
@@ -8,6 +9,15 @@ export default container => {
   }
 
   const params = parseApiKey(document)
+
+  let lang = 'auto'
+  if (container.dataset.lang && 'auto' === container.dataset.lang) {
+    lang = util.getLang()
+  } else if (container.dataset.lang && 'ja' === container.dataset.lang) {
+    lang = 'ja'
+  } else {
+    lang = 'en'
+  }
 
   return {
     lat: 0,
@@ -30,7 +40,7 @@ export default container => {
     cluster: 'on',
     clusterColor: '#ff0000',
     style: 'geolonia/basic',
-    lang: 'auto',
+    lang: lang,
     plugin: 'off',
     key: params.key,
     stage: params.stage,

--- a/src/lib/parse-atts.js
+++ b/src/lib/parse-atts.js
@@ -15,8 +15,10 @@ export default container => {
     lang = util.getLang()
   } else if (container.dataset.lang && 'ja' === container.dataset.lang) {
     lang = 'ja'
-  } else {
+  } else if (container.dataset.lang && 'ja' !== container.dataset.lang) {
     lang = 'en'
+  } else {
+    lang = util.getLang()
   }
 
   return {


### PR DESCRIPTION
* setStyle() をコールされた際に `geolonia/basic` のような指定方法を適切に処理できるように同名のメソッドを追加し、そのメソッドで `mapboxgl.Map.setStyle()` をコールするように修正。
* `data-*` などの属性値の取得を `parseAtts()` メソッド内で完結するように修正。 

Related: #123 