### PR TITLE
Key into global

### DIFF
--- a/src/embed.js
+++ b/src/embed.js
@@ -6,6 +6,7 @@ import 'intersection-observer'
 import mapboxgl from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import './style.css'
+import parseApiKey from './lib/parse-api-key'
 import GeoloniaMap from './lib/geolonia-map'
 import GeoloniaMarker from './lib/geolonia-marker'
 import * as util from './lib/util'
@@ -51,6 +52,7 @@ if ( util.checkPermission() ) {
   const lazyContainers = document.querySelectorAll('.geolonia:not([data-lazy="off"])')
 
   window.geolonia = mapboxgl
+  window.geolonia.geolonia = parseApiKey(document)
   window.geolonia.Map = GeoloniaMap
   window.geolonia.Marker = GeoloniaMarker
   window.geolonia.registerPlugin = plugin => {

--- a/src/lib/parse-api-key.js
+++ b/src/lib/parse-api-key.js
@@ -2,10 +2,6 @@ import urlParse from 'url-parse'
 import querystring from 'querystring'
 
 export default document => {
-  if (window.geolonia.geolonia && window.geolonia.geolonia.key && window.geolonia.geolonia.stage) {
-    return
-  }
-
   const scripts = document.getElementsByTagName('script')
   const params = {
     key: 'YOUR-API-KEY',
@@ -28,8 +24,5 @@ export default document => {
     }
   }
 
-  window.geolonia.geolonia = {
-    key: params.key,
-    stage: params.stage,
-  }
+  return params
 }

--- a/src/lib/parse-api-key.js
+++ b/src/lib/parse-api-key.js
@@ -2,6 +2,10 @@ import urlParse from 'url-parse'
 import querystring from 'querystring'
 
 export default document => {
+  if (window.geolonia.geolonia && window.geolonia.geolonia.key && window.geolonia.geolonia.stage) {
+    return
+  }
+
   const scripts = document.getElementsByTagName('script')
   const params = {
     key: 'YOUR-API-KEY',
@@ -24,5 +28,8 @@ export default document => {
     }
   }
 
-  return params
+  window.geolonia.geolonia = {
+    key: params.key,
+    stage: params.stage,
+  }
 }

--- a/src/lib/parse-atts.js
+++ b/src/lib/parse-atts.js
@@ -8,7 +8,7 @@ export default container => {
     container.dataset = {}
   }
 
-  const params = parseApiKey(document)
+  parseApiKey(document)
 
   let lang = 'auto'
   if (container.dataset.lang && 'auto' === container.dataset.lang) {
@@ -44,8 +44,8 @@ export default container => {
     style: 'geolonia/basic',
     lang: lang,
     plugin: 'off',
-    key: params.key,
-    stage: params.stage,
+    key: window.geolonia.geolonia.key,
+    stage: window.geolonia.geolonia.stage,
     loader: 'on',
     ...container.dataset,
   }

--- a/src/lib/parse-atts.js
+++ b/src/lib/parse-atts.js
@@ -1,14 +1,11 @@
 'use strict'
 
-import parseApiKey from './parse-api-key'
 import * as util from './util'
 
 export default container => {
   if (!container.dataset) {
     container.dataset = {}
   }
-
-  parseApiKey(document)
 
   let lang = 'auto'
   if (container.dataset.lang && 'auto' === container.dataset.lang) {


### PR DESCRIPTION
これまで、`.geolonia` の回数分だけAPIキーとステージのパースが実行されていたが、`renderGeoloniaMap` が実行される前に取得する＆グローバル変数に保存することで、一回だけしか実行されないようにした。

Related: #128 