### PR TITLE
Enable map.remove()

### DIFF
--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -166,11 +166,18 @@ export default class GeoloniaMap extends mapboxgl.Map {
     return map
   }
 
+  /**
+   *
+   * @param {string|null} style style identity or `null` when map.remove()
+   * @param {*} options
+   */
   setStyle(style, options = {}) {
+    if (style !== null) {
     // It can't access `this` because `setStyle()` will be called with `super()`.
     // So, we need to run `parseAtts()` again(?)
-    const atts = parseAtts(this.getContainer())
-    style = util.getStyle(style, atts)
+      const atts = parseAtts(this.getContainer())
+      style = util.getStyle(style, atts)
+    }
 
     // Calls `mapboxgl.Map.setStyle()`.
     super.setStyle.call(this, style, options)


### PR DESCRIPTION
`setStyle` will be called when `map.remove()`.
This patch makes Geolonia API follow that of Mapbox and enable it to call `map.remove()` safely.
Now we can avoid the WebGL trouble with `Too many WebGL contexts`.