### PR TITLE
Use querystring for cloudfront logging

### DIFF
--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -56,7 +56,7 @@ export default class GeoloniaMap extends mapboxgl.Map {
       if (resourceType === 'Source' && url.startsWith('https://api.geolonia.com')) {
         url = `${atts.apiUrl}/sources`
         return {
-          url: `${url}?key=${atts.key}`, 
+          url: `${url}?key=${atts.key}`,
           headers: { 'X-Geolonia-Api-Key': atts.key },
         }
       }

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -56,7 +56,7 @@ export default class GeoloniaMap extends mapboxgl.Map {
       if (resourceType === 'Source' && url.startsWith('https://api.geolonia.com')) {
         url = `${atts.apiUrl}/sources`
         return {
-          url: url,
+          url: `${url}?key=${atts.key}`, 
           headers: { 'X-Geolonia-Api-Key': atts.key },
         }
       }


### PR DESCRIPTION
サーバー側の都合によりクエリストリングでパブリックな API キーを転送します。
