### PR TITLE
transformRequest は options として与えられたものも許容する

### DIFF
--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -52,7 +52,7 @@ export default class GeoloniaMap extends mapboxgl.Map {
     }
 
     // Pass API key to `/sources` (tile json).
-    options.transformRequest = (url, resourceType) => {
+    const transformRequest = (url, resourceType) => {
       if (resourceType === 'Source' && url.startsWith('https://api.geolonia.com')) {
         url = `${atts.apiUrl}/sources`
         return {
@@ -60,10 +60,15 @@ export default class GeoloniaMap extends mapboxgl.Map {
           headers: { 'X-Geolonia-Api-Key': atts.key },
         }
       }
+
+      // Additional transformation
+      if (typeof options.transformRequest === 'function') {
+        return options.transformRequest(url, resourceType)
+      }
     }
 
     // Generate Map
-    super(options)
+    super({ ...options, transformRequest })
     const map = this
 
     // Note: GeoloniaControl should be placed before another controls.

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -52,7 +52,8 @@ export default class GeoloniaMap extends mapboxgl.Map {
     }
 
     // Pass API key to `/sources` (tile json).
-    const transformRequest = (url, resourceType) => {
+    const _transformRequest = options.transformRequest
+    options.transformRequest = (url, resourceType) => {
       if (resourceType === 'Source' && url.startsWith('https://api.geolonia.com')) {
         url = `${atts.apiUrl}/sources`
         return {
@@ -62,13 +63,13 @@ export default class GeoloniaMap extends mapboxgl.Map {
       }
 
       // Additional transformation
-      if (typeof options.transformRequest === 'function') {
-        return options.transformRequest(url, resourceType)
+      if (typeof _transformRequest === 'function') {
+        return _transformRequest(url, resourceType)
       }
     }
 
     // Generate Map
-    super({ ...options, transformRequest })
+    super(options)
     const map = this
 
     // Note: GeoloniaControl should be placed before another controls.


### PR DESCRIPTION
`transformRequest` は、 コンストラクタのオプションとして与えられるものも実行されるようにし、Geolonia 固有の transformRequest の条件と合致しなかった場合に適用するようになりました。
これにより、Geolonia のデータソース以外も同時に認証することが可能になります。