### PR TITLE
`class=geolonia` と `new geolonia.Map()` の併用を禁止

### DIFF
--- a/src/embed.js
+++ b/src/embed.js
@@ -7,7 +7,7 @@ import mapboxgl from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import './style.css'
 import parseApiKey from './lib/parse-api-key'
-import GeoloniaMap from './lib/geolonia-map'
+import { GeoloniaMap, GeoloniaDefaultMap } from './lib/geolonia-map'
 import GeoloniaMarker from './lib/geolonia-marker'
 import * as util from './lib/util'
 import parseAtts from './lib/parse-atts'
@@ -22,7 +22,7 @@ if ( util.checkPermission() ) {
    * @param {HTMLElement} target
    */
   const renderGeoloniaMap = target => {
-    const map = new GeoloniaMap(target)
+    const map = new GeoloniaDefaultMap(target)
 
     // plugin
     const atts = parseAtts(target)

--- a/src/embed.js
+++ b/src/embed.js
@@ -7,7 +7,7 @@ import mapboxgl from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import './style.css'
 import parseApiKey from './lib/parse-api-key'
-import { GeoloniaMap, GeoloniaDefaultMap } from './lib/geolonia-map'
+import GeoloniaMap from './lib/geolonia-map'
 import GeoloniaMarker from './lib/geolonia-marker'
 import * as util from './lib/util'
 import parseAtts from './lib/parse-atts'
@@ -18,11 +18,11 @@ if ( util.checkPermission() ) {
   const plugins = []
 
   /**
-   *
+   * render maps with .geolonia
    * @param {HTMLElement} target
    */
   const renderGeoloniaMap = target => {
-    const map = new GeoloniaDefaultMap(target)
+    const map = new GeoloniaMap(target, { __allowGeoloniaClassName: true })
 
     // plugin
     const atts = parseAtts(target)

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -27,7 +27,7 @@ const isCssSelector = string => {
 }
 
 /**
- * Render the map
+ * Render the map with `class=geolonia`.
  *
  * @param container
  */
@@ -210,10 +210,14 @@ export class GeoloniaDefaultMap extends mapboxgl.Map {
   }
 }
 
-// Prevent `.geolonia` to be rendered with `new window.geolonia.Map()`
+/**
+ *  Render the map with `new window.geolonia.Map()`.
+ *
+ */
 export class GeoloniaMap extends GeoloniaDefaultMap {
   constructor(params) {
     const container = util.getContainer(params)
+    // Prevent `.geolonia` because those containers should be already rendered.
     if (container.classList.contains('geolonia')) {
       throw new Error('You cannot use　`class=geolonia` with `new geolonia.Map`.')
     } else {

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -27,13 +27,18 @@ const isCssSelector = string => {
 }
 
 /**
- * Render the map with `class=geolonia`.
+ * Render the map.
  *
  * @param container
  */
-export class GeoloniaDefaultMap extends mapboxgl.Map {
-  constructor(params) {
+export default class GeoloniaMap extends mapboxgl.Map {
+  constructor(params, embedOptions = {}) {
     const container = util.getContainer(params)
+
+    if (!embedOptions.__allowGeoloniaClassName && container.classList.contains('geolonia')) {
+      throw new Error('[Geolonia] You cannot use `class=geolonia` with advanced customization with `new geolonia.Map()`.')
+    }
+
     const atts = parseAtts(container)
 
     const options = util.getOptions(container, params, atts)
@@ -207,21 +212,5 @@ export class GeoloniaDefaultMap extends mapboxgl.Map {
 
     // Calls `mapboxgl.Map.setStyle()`.
     super.setStyle.call(this, style, options)
-  }
-}
-
-/**
- *  Render the map with `new window.geolonia.Map()`.
- *
- */
-export class GeoloniaMap extends GeoloniaDefaultMap {
-  constructor(params) {
-    const container = util.getContainer(params)
-    // Prevent `.geolonia` because those containers should be already rendered.
-    if (container.classList.contains('geolonia')) {
-      throw new Error('You cannot use　`class=geolonia` with `new geolonia.Map`.')
-    } else {
-      super(params)
-    }
   }
 }

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -31,7 +31,7 @@ const isCssSelector = string => {
  *
  * @param container
  */
-export default class GeoloniaMap extends mapboxgl.Map {
+export class GeoloniaDefaultMap extends mapboxgl.Map {
   constructor(params) {
     const container = util.getContainer(params)
     const atts = parseAtts(container)
@@ -207,5 +207,17 @@ export default class GeoloniaMap extends mapboxgl.Map {
 
     // Calls `mapboxgl.Map.setStyle()`.
     super.setStyle.call(this, style, options)
+  }
+}
+
+// Prevent `.geolonia` to be rendered with `new window.geolonia.Map()`
+export class GeoloniaMap extends GeoloniaDefaultMap {
+  constructor(params) {
+    const container = util.getContainer(params)
+    if (container.classList.contains('geolonia')) {
+      throw new Error('You cannot use　`class=geolonia` with `new geolonia.Map`.')
+    } else {
+      super(params)
+    }
   }
 }

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -36,7 +36,7 @@ export default class GeoloniaMap extends mapboxgl.Map {
     const container = util.getContainer(params)
 
     if (!embedOptions.__allowGeoloniaClassName && container.classList.contains('geolonia')) {
-      throw new Error('[Geolonia]  `class=geolonia` is not available for advanced customization using `geolonia.Map()`.')
+      throw new Error('[Geolonia] `class=geolonia` is not available for advanced customization using `geolonia.Map()`.')
     }
 
     const atts = parseAtts(container)

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -36,7 +36,7 @@ export default class GeoloniaMap extends mapboxgl.Map {
     const container = util.getContainer(params)
 
     if (!embedOptions.__allowGeoloniaClassName && container.classList.contains('geolonia')) {
-      throw new Error('[Geolonia] You cannot use `class=geolonia` with advanced customization with `new geolonia.Map()`.')
+      throw new Error('[Geolonia]  `class=geolonia` is not available for advanced customization using `geolonia.Map()`.')
     }
 
     const atts = parseAtts(container)


### PR DESCRIPTION
`<div id="map" class="geolonia">` などとすると発生する #169 の不具合はすでにドキュメント化されていました。

https://docs.geolonia.com/tutorial/010/#class-%E5%B1%9E%E6%80%A7-geolonia-%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6

この修正では、このような API の使い方をした場合、エラーを発生させるようにしました。