### PR TITLE
`.geolonia` があっても `new geolonia.Map()` で動作するように修正する

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -126,6 +126,7 @@
     <h2>Custom with JavaScript</h2>
     <div
       id="my-map"
+      class="geolonia"
       data-lat="35.681236"
       data-lng="139.767125"
       data-zoom="9"

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -34,8 +34,8 @@ const isCssSelector = string => {
 export default class GeoloniaMap extends mapboxgl.Map {
   constructor(params) {
     const container = util.getContainer(params)
-    if (container._GeoloniaMap) {
-      return container._GeoloniaMap
+    if (container.geoloniaMap) {
+      return container.geoloniaMap
     }
 
     const atts = parseAtts(container)
@@ -188,7 +188,7 @@ export default class GeoloniaMap extends mapboxgl.Map {
       }
     })
 
-    container._GeoloniaMap = map
+    container.geoloniaMap = map
 
     return map
   }

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -34,6 +34,10 @@ const isCssSelector = string => {
 export default class GeoloniaMap extends mapboxgl.Map {
   constructor(params) {
     const container = util.getContainer(params)
+    if (container._GeoloniaMap) {
+      return container._GeoloniaMap
+    }
+
     const atts = parseAtts(container)
 
     const options = util.getOptions(container, params, atts)
@@ -184,6 +188,8 @@ export default class GeoloniaMap extends mapboxgl.Map {
         })
       }
     })
+
+    container._GeoloniaMap = map
 
     return map
   }

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -74,7 +74,6 @@ export default class GeoloniaMap extends mapboxgl.Map {
 
     // Generate Map
     super(options)
-    console.log(options)
     const map = this
 
     // Note: GeoloniaControl should be placed before another controls.


### PR DESCRIPTION
#169 