### PR TITLE
DeckGL をサポート

### DIFF
--- a/docs/deck.html
+++ b/docs/deck.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="./style.css">
+  <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+  <title>Deck.GL + @geolonia/embed</title>
+  <style>
+    body {
+      margin: 0;
+      width: 100vw;
+      height: 100vh;
+      overflow: hidden;
+    }
+  </style>
+</head>
+
+<body>
+
+  <script src="https://unpkg.com/deck.gl@latest/dist.min.js"></script>
+  <script src="./embed.js?geolonia-api-key=YOUR-API-KEY"></script>
+
+  <script>
+    const { DeckGL } = deck;
+
+    const map = new DeckGL({
+      mapStyle: 'geolonia/basic',
+      initialViewState: {
+        longitude: 139.7450316,
+        latitude: 35.6759323,
+        zoom: 8,
+        maxZoom: 20,
+        pitch: 0,
+        bearing: 0
+      },
+      controller: true,
+      layers: []
+    });
+
+  </script>
+
+</body>
+</html>

--- a/docs/webpack.deck-config.js
+++ b/docs/webpack.deck-config.js
@@ -1,0 +1,20 @@
+const config = require('../webpack.config')
+
+module.exports = {
+  ...config,
+  output: {
+    path: __dirname,
+    filename: 'embed.js',
+  },
+  devtool: 'inline-source-map',
+
+  devServer: {
+    open: true,
+    openPage: 'deck.html',
+    contentBase: __dirname,
+    watchContentBase: true,
+    host: 'localhost',
+    port: 3000,
+    disableHostCheck: true
+  },
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "src/embed.d.ts",
   "scripts": {
     "start": "webpack-dev-server --mode development --config ./docs/webpack.config.js",
+    "start:deck": "webpack-dev-server --mode development --config ./docs/webpack.deck-config.js",
     "build": "npm run build:embed && npm run build:docs",
     "build:docs": "webpack -p --config ./docs/webpack.config.js",
     "build:embed": "webpack -p  --config ./webpack.config.js",

--- a/src/embed.js
+++ b/src/embed.js
@@ -6,7 +6,6 @@ import 'intersection-observer'
 import mapboxgl from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import './style.css'
-import parseApiKey from './lib/parse-api-key'
 import GeoloniaMap from './lib/geolonia-map'
 import GeoloniaMarker from './lib/geolonia-marker'
 import * as util from './lib/util'
@@ -55,18 +54,14 @@ if ( util.checkPermission() ) {
   const containers = document.querySelectorAll('.geolonia[data-lazy-loading="off"]')
   const lazyContainers = document.querySelectorAll('.geolonia:not([data-lazy-loading="off"])')
 
-  window.geolonia = mapboxgl
-  const { key, stage } = parseApiKey(document)
-  window.geolonia.accessToken = key
-  window.geolonia.baseApiUrl = `https://api.geolonia.com/${stage}`
+  window.geolonia = window.mapboxgl = mapboxgl
+
   window.geolonia.Map = GeoloniaMap
   window.geolonia.Marker = GeoloniaMarker
   window.geolonia.registerPlugin = plugin => {
     plugins.push(plugin)
     return void 0
   }
-
-  window.mapboxgl = mapboxgl
 
   // render Map immediately
   for (let i = 0; i < containers.length; i++) {

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -39,7 +39,6 @@ export default class GeoloniaMap extends mapboxgl.Map {
     }
 
     const atts = parseAtts(container)
-
     const options = util.getOptions(container, params, atts)
 
     // Getting content should be fire just before initialize the map.

--- a/src/lib/parse-api-key.js
+++ b/src/lib/parse-api-key.js
@@ -5,7 +5,7 @@ export default document => {
   const scripts = document.getElementsByTagName('script')
   const params = {
     key: 'YOUR-API-KEY',
-    stage: 'v1',
+    stage: 'dev',
   }
 
   for (const script of scripts) {
@@ -16,7 +16,7 @@ export default document => {
       params.key = q['geolonia-api-key'] || 'YOUR-API-KEY'
 
       const res = pathname.match( /^\/(v[0-9.]+)\/embed/ )
-      if (res && res[1] !== 'dev') {
+      if (res && res[1]) {
         params.stage = res[1]
       }
 

--- a/src/lib/parse-api-key.test.js
+++ b/src/lib/parse-api-key.test.js
@@ -10,7 +10,7 @@ describe('parse api key from dom', () => {
 
     const params = parseApiKey(mocDocument)
     assert.deepEqual('abc', params.key)
-    assert.deepEqual('v1', params.stage)
+    assert.deepEqual('dev', params.stage)
   })
 
   it('should parse with geolonia flag', () => {
@@ -21,7 +21,7 @@ describe('parse api key from dom', () => {
 
     const params = parseApiKey(mocDocument)
     assert.deepEqual('def', params.key)
-    assert.deepEqual('v1', params.stage)
+    assert.deepEqual('dev', params.stage)
   })
 
   it('should be "YOUR-API-KEY" and "dev"', () => {
@@ -32,7 +32,7 @@ describe('parse api key from dom', () => {
 
     const params = parseApiKey(mocDocument)
     assert.deepEqual('YOUR-API-KEY', params.key)
-    assert.deepEqual('v1', params.stage)
+    assert.deepEqual('dev', params.stage)
   })
 
   it('should be "YOUR-API-KEY" and "v1"', () => {

--- a/src/lib/parse-atts.js
+++ b/src/lib/parse-atts.js
@@ -1,5 +1,6 @@
 'use strict'
 
+import parseApiKey from './parse-api-key'
 import * as util from './util'
 
 export default container => {
@@ -17,6 +18,8 @@ export default container => {
   } else {
     lang = util.getLang()
   }
+
+  const { key, stage } = parseApiKey(container)
 
   return {
     lat: 0,
@@ -41,8 +44,8 @@ export default container => {
     style: 'geolonia/basic',
     lang: lang,
     plugin: 'off',
-    key: window.geolonia.config.ACCESS_TOKEN,
-    apiUrl: window.geolonia.config.API_URL,
+    key: key,
+    apiUrl: `https://api.geolonia.com/${stage}`,
     loader: 'on',
     minZoom: '',
     maxZoom: 20,

--- a/src/lib/parse-atts.test.js
+++ b/src/lib/parse-atts.test.js
@@ -1,5 +1,6 @@
 import parseAtts from './parse-atts'
 import assert from 'assert'
+import { JSDOM } from 'jsdom'
 
 describe('tests for parse Attributes', () => {
 
@@ -13,11 +14,11 @@ describe('tests for parse Attributes', () => {
   })
 
   it('should parse attribute', () => {
-    const container = {
-      dataset: {},
-    }
+    const { document: mocDocument } = new JSDOM(`<html><body>
+          <script type="text/javascript" src="https://cdn.geolonia.com/v1/embed?geolonia-api-key=YOUR-API-KEY"></script>
+          </body></html>`).window
 
-    const atts = parseAtts(container)
+    const atts = parseAtts(mocDocument)
     assert.deepStrictEqual(atts, {
       lat: 0,
       lng: 0,
@@ -41,8 +42,8 @@ describe('tests for parse Attributes', () => {
       style: 'geolonia/basic',
       lang: 'ja',
       plugin: 'off',
-      key: void 0,
-      apiUrl: void 0,
+      key: 'YOUR-API-KEY',
+      apiUrl: 'https://api.geolonia.com/v1',
       loader: 'on',
       minZoom: '',
       maxZoom: 20,


### PR DESCRIPTION
DeckGL のベースレイヤーとして地図を設置したときに、タイルの認証が通らない不具合を修正した。