### PR TITLE
Bug fix to handle API key with Deck.GL

### DIFF
--- a/docs/deck.html
+++ b/docs/deck.html
@@ -19,7 +19,7 @@
 <body>
 
   <script type="text/javascript" src="https://unpkg.com/deck.gl@latest/dist.min.js"></script>
-  <script type="text/javascript" src="http://localhost:3000/embed.js?geolonia-api-key=YOUR-API-KEY"></script>
+  <script type="text/javascript" src="./embed.js?geolonia-api-key=YOUR-API-KEY"></script>
 
   <script>
     const { DeckGL, GeoJsonLayer, ArcLayer } = deck;

--- a/docs/deck.html
+++ b/docs/deck.html
@@ -18,26 +18,73 @@
 
 <body>
 
-  <script src="https://unpkg.com/deck.gl@latest/dist.min.js"></script>
-  <script src="./embed.js?geolonia-api-key=YOUR-API-KEY"></script>
+  <script type="text/javascript" src="https://unpkg.com/deck.gl@latest/dist.min.js"></script>
+  <script type="text/javascript" src="http://localhost:3000/embed.js?geolonia-api-key=YOUR-API-KEY"></script>
 
   <script>
-    const { DeckGL } = deck;
+    const { DeckGL, GeoJsonLayer, ArcLayer } = deck;
 
-    const map = new DeckGL({
-      mapStyle: 'geolonia/basic',
-      initialViewState: {
-        longitude: 139.7450316,
-        latitude: 35.6759323,
-        zoom: 8,
-        maxZoom: 20,
-        pitch: 0,
-        bearing: 0
-      },
-      controller: true,
-      layers: []
+    const air_ports = 'https://assets.codepen.io/4210065/airports.geojson'
+
+    // 空港の GeoJSON を取得して Deck.GL のレイヤーを設置
+    fetch(air_ports).then(res => {
+      return res.json()
+    }).then(data => {
+      const layers = [
+        new GeoJsonLayer({
+          id: 'airports',
+          data: data,
+          filled: true,
+          pointRadiusMinPixels: 2,
+          pointRadiusScale: 1000,
+          getRadius: () => 5,
+          getFillColor: [255, 255, 100, 90],
+          pickable: true,
+          autoHighlight: true,
+        }),
+      ]
+
+      for (let i = 0; i < data.features.length; i++) {
+        const airport = data.features[i]
+        if ('cf04_00030' !== airport.properties.C28_000) {
+          continue // 羽田以外は除外
+        }
+        const arc = new ArcLayer({
+          id: `arcs-${i}`,
+          data: air_ports,
+          greatCircle: true,
+          wrapLongitude: true,
+          dataTransform: d => {
+            return d.features
+          },
+          getSourcePosition: () => airport.geometry.coordinates,
+          getTargetPosition: f => f.geometry.coordinates,
+          getSourceColor: [200, 0, 80],
+          getTargetColor: [150, 200, 255],
+          getWidth: 1,
+        })
+
+        layers.push(arc)
+      }
+
+      new DeckGL({
+        mapStyle: 'geolonia/midnight',
+        initialViewState: {
+          latitude: 37.092,
+          longitude: 138.219,
+          zoom: 6,
+          bearing: 0,
+          pitch: 60,
+        },
+        controller: true,
+        layers: layers
+      });
+    })
+
+    // コンテキストメニューを無効化
+    document.body.addEventListener('contextmenu', e => {
+      e.preventDefault();
     });
-
   </script>
 
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "css-loader": "^2.1.0",
         "eslint": "^7.16.0",
         "jsdom": "^16.2.2",
+        "jsdom-global": "^3.0.2",
         "mocha": "^5.2.0",
         "prettier-eslint": "^12.0.0",
         "prettier-eslint-cli": "^5.0.0",
@@ -5151,34 +5152,30 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -5186,17 +5183,15 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5204,75 +5199,66 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -5282,27 +5268,24 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -5316,10 +5299,9 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5337,17 +5319,15 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -5357,20 +5337,18 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5378,27 +5356,24 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -5408,17 +5383,15 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5428,17 +5401,15 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "0.0.8",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -5446,20 +5417,18 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
     },
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "minimist": "0.0.8"
       },
@@ -5469,17 +5438,15 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.4.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -5494,10 +5461,9 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -5516,10 +5482,9 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -5530,27 +5495,24 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.7",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1"
@@ -5558,10 +5520,9 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -5571,60 +5532,54 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -5632,27 +5587,24 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -5665,17 +5617,15 @@
     },
     "node_modules/fsevents/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.6",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -5688,10 +5638,9 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -5701,65 +5650,57 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -5771,10 +5712,9 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -5784,20 +5724,18 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -5813,34 +5751,30 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -7046,6 +6980,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/jsdom-global": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
+      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
+      "dev": true,
+      "peerDependencies": {
+        "jsdom": ">=10.0.0"
+      }
+    },
     "node_modules/jsdom/node_modules/acorn": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
@@ -7259,9 +7202,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "node_modules/lodash.memoize": {
@@ -8699,9 +8642,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
-      "integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
+      "version": "7.0.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
       "dev": true,
       "dependencies": {
         "chalk": "^2.4.2",
@@ -8710,6 +8653,10 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-modules-extract-imports": {
@@ -8739,9 +8686,9 @@
       }
     },
     "node_modules/postcss-modules-scope": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.1.tgz",
-      "integrity": "sha512-OXRUPecnHCg8b9xWvldG/jUpRIGPNRka0r4D4j0ESUU2/5IOnpsjfPPmDprM3Ih8CgZ8FXjWqaniK5v4rWt3oQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
+      "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
       "dev": true,
       "dependencies": {
         "postcss": "^7.0.6",
@@ -10826,9 +10773,9 @@
       }
     },
     "node_modules/ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "dev": true,
       "dependencies": {
         "figgy-pudding": "^3.5.1"
@@ -11116,12 +11063,6 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
-    },
-    "node_modules/table/node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
     },
     "node_modules/tapable": {
       "version": "1.1.3",
@@ -17120,26 +17061,22 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -17148,14 +17085,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -17164,38 +17099,32 @@
         "chownr": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "debug": {
           "version": "3.2.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -17203,26 +17132,22 @@
         "deep-extend": {
           "version": "0.6.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "minipass": "^2.6.0"
           }
@@ -17230,14 +17155,12 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -17252,8 +17175,7 @@
         "glob": {
           "version": "7.1.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -17266,14 +17188,12 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -17281,8 +17201,7 @@
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -17290,8 +17209,7 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -17300,20 +17218,17 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -17321,14 +17236,12 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -17336,14 +17249,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -17352,8 +17263,7 @@
         "minizlib": {
           "version": "1.3.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "minipass": "^2.9.0"
           }
@@ -17361,8 +17271,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -17370,14 +17279,12 @@
         "ms": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "needle": {
           "version": "2.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -17387,8 +17294,7 @@
         "node-pre-gyp": {
           "version": "0.14.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -17405,8 +17311,7 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -17415,8 +17320,7 @@
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
@@ -17424,14 +17328,12 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "npm-packlist": {
           "version": "1.4.7",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1"
@@ -17440,8 +17342,7 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -17452,20 +17353,17 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "wrappy": "1"
           }
@@ -17473,20 +17371,17 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -17495,20 +17390,17 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -17519,16 +17411,14 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "extraneous": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -17542,8 +17432,7 @@
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -17551,44 +17440,37 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "semver": {
           "version": "5.7.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -17596,8 +17478,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -17607,8 +17488,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -17616,14 +17496,12 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "tar": {
           "version": "4.4.13",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -17637,14 +17515,12 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
+          "extraneous": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
@@ -17652,14 +17528,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "extraneous": true
         }
       }
     },
@@ -18654,6 +18528,13 @@
         }
       }
     },
+    "jsdom-global": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
+      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
+      "dev": true,
+      "requires": {}
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -18812,9 +18693,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.memoize": {
@@ -19998,9 +19879,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
-      "integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
+      "version": "7.0.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -20040,9 +19921,9 @@
       }
     },
     "postcss-modules-scope": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.1.tgz",
-      "integrity": "sha512-OXRUPecnHCg8b9xWvldG/jUpRIGPNRka0r4D4j0ESUU2/5IOnpsjfPPmDprM3Ih8CgZ8FXjWqaniK5v4rWt3oQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
+      "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.6",
@@ -21773,9 +21654,9 @@
       }
     },
     "ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"
@@ -22024,12 +21905,6 @@
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
           }
-        },
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:embed": "webpack -p  --config ./webpack.config.js",
     "format": "prettier-eslint \"./src/**/*.js\" --write",
     "lint": "eslint \"src/**/*.js\"",
-    "test": "npm run lint && mocha"
+    "test": "npm run lint && mocha -r jsdom-global/register"
   },
   "author": "Geolonia inc.",
   "repository": {
@@ -34,6 +34,7 @@
     "css-loader": "^2.1.0",
     "eslint": "^7.16.0",
     "jsdom": "^16.2.2",
+    "jsdom-global": "^3.0.2",
     "mocha": "^5.2.0",
     "prettier-eslint": "^12.0.0",
     "prettier-eslint-cli": "^5.0.0",

--- a/src/embed.js
+++ b/src/embed.js
@@ -58,9 +58,10 @@ if ( util.checkPermission() ) {
   window.geolonia = window.mapboxgl = mapboxgl
 
   // This is required for correct initialization! Don't delete!
-  const { key, stage } = parseApiKey(document)
-  window.geolonia.accessToken = key
-  window.geolonia.baseApiUrl = `https://api.geolonia.com/${stage}`
+  const { key } = parseApiKey(document)
+  if ('no-api-key' === key) {
+    console.error('Missing API key.') // eslint-disable-line
+  }
 
   window.geolonia.Map = GeoloniaMap
   window.geolonia.Marker = GeoloniaMarker

--- a/src/lib/parse-api-key.js
+++ b/src/lib/parse-api-key.js
@@ -2,9 +2,16 @@ import urlParse from 'url-parse'
 import querystring from 'querystring'
 
 export default document => {
+  if (window.geolonia.apiKey && window.geolonia.stage) {
+    return {
+      key: window.geolonia.apiKey,
+      stage: window.geolonia.stage,
+    }
+  }
+
   const scripts = document.getElementsByTagName('script')
   const params = {
-    key: 'YOUR-API-KEY',
+    key: 'no-api-key',
     stage: 'dev',
   }
 
@@ -23,6 +30,9 @@ export default document => {
       break
     }
   }
+
+  window.geolonia.apiKey = params.key
+  window.geolonia.stage = params.stage
 
   return params
 }

--- a/src/lib/parse-api-key.js
+++ b/src/lib/parse-api-key.js
@@ -2,10 +2,10 @@ import urlParse from 'url-parse'
 import querystring from 'querystring'
 
 export default document => {
-  if (window.geolonia.apiKey && window.geolonia.stage) {
+  if (window.geolonia._apiKey && window.geolonia._stage) {
     return {
-      key: window.geolonia.apiKey,
-      stage: window.geolonia.stage,
+      key: window.geolonia._apiKey,
+      stage: window.geolonia._stage,
     }
   }
 
@@ -31,8 +31,8 @@ export default document => {
     }
   }
 
-  window.geolonia.apiKey = params.key
-  window.geolonia.stage = params.stage
+  window.geolonia._apiKey = params.key
+  window.geolonia._stage = params.stage
 
   return params
 }

--- a/src/lib/parse-api-key.test.js
+++ b/src/lib/parse-api-key.test.js
@@ -8,6 +8,8 @@ describe('parse api key from dom', () => {
       <script src="https://external.example.com/?geolonia-api-key=abc"></script>
     </body></html>`).window
 
+    window.geolonia = {}
+
     const params = parseApiKey(mocDocument)
     assert.deepEqual('abc', params.key)
     assert.deepEqual('dev', params.stage)
@@ -18,6 +20,8 @@ describe('parse api key from dom', () => {
       <script src="https://external.example.com/jquery.js"></script>
       <script src="https://external.example.com/?geolonia-api-key=def"></script>
     </body></html>`).window
+
+    window.geolonia = {}
 
     const params = parseApiKey(mocDocument)
     assert.deepEqual('def', params.key)
@@ -30,6 +34,8 @@ describe('parse api key from dom', () => {
       <script type="text/javascript" src="https://api.geolonia.com/dev/embed?geolonia-api-key=YOUR-API-KEY"></script>
     </body></html>`).window
 
+    window.geolonia = {}
+
     const params = parseApiKey(mocDocument)
     assert.deepEqual('YOUR-API-KEY', params.key)
     assert.deepEqual('dev', params.stage)
@@ -41,6 +47,8 @@ describe('parse api key from dom', () => {
       <script type="text/javascript" src="https://api.geolonia.com/v1/embed?geolonia-api-key=YOUR-API-KEY"></script>
     </body></html>`).window
 
+    window.geolonia = {}
+
     const params = parseApiKey(mocDocument)
     assert.deepEqual('YOUR-API-KEY', params.key)
     assert.deepEqual('v1', params.stage)
@@ -51,6 +59,8 @@ describe('parse api key from dom', () => {
       <script src="https://external.example.com/jquery.js"></script>
       <script type="text/javascript" src="https://api.geolonia.com/v123.4/embed?geolonia-api-key=YOUR-API-KEY"></script>
     </body></html>`).window
+
+    window.geolonia = {}
 
     const params = parseApiKey(mocDocument)
     assert.deepEqual('YOUR-API-KEY', params.key)


### PR DESCRIPTION
* Deck.GL 用のサンプルを修正して不具合を再現。
* 地図をレンダリングしたあとで、Embed API 用のスクリプトタグが DOM から取り除かれるケースを想定して、一度取得した APIキー及びステージは、 `window.geolonia` 以下に格納して、次回以降 `praseApiKey()` がコールされたらそれを返すように修正した。
* mocha で `window` 変数にアクセスできるように `jsdom-global` を追加。
* `npm audit fix` を実行