### PR TITLE
ローディング中にピンチイン・ピンチアウトを含む2本指のジェスチャーを無効化

### DIFF
--- a/docs/fullscreen.html
+++ b/docs/fullscreen.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <link rel="stylesheet" href="./style.css">
   <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
-  <title>@geolonia/embed</title>
+  <title>@geolonia/embed Examples with fullscreen or 100% width and height</title>
   <style>
     html, body, .geolonia {
       width: 100%;
@@ -15,22 +15,14 @@
 </head>
 
 <body>
-  <h1>@geolonia/embed</h1>
-
-  Examples with fullscreen or 100% width and height
-
-  <div class="example">
-    <h2>Basic map</h2>
-    <div
-      class="geolonia"
-      data-lat="35.681236"
-      data-lng="139.767125"
-      data-zoom="16"
-      data-geolonia-fork-me-disabled="on"
-      data-fullscreen-control="on"
-    ></div>
-  </div>
-
+  <div
+    class="geolonia"
+    data-lat="35.681236"
+    data-lng="139.767125"
+    data-zoom="16"
+    data-geolonia-fork-me-disabled="on"
+    data-fullscreen-control="on"
+  ></div>
   <script src="./embed.js?geolonia-api-key=YOUR-API-KEY"></script>
 </body>
 

--- a/docs/fullscreen.html
+++ b/docs/fullscreen.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="./style.css">
+  <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+  <title>@geolonia/embed</title>
+  <style>
+    html, body, .geolonia {
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>@geolonia/embed</h1>
+
+  Examples with fullscreen or 100% width and height
+
+  <div class="example">
+    <h2>Basic map</h2>
+    <div
+      class="geolonia"
+      data-lat="35.681236"
+      data-lng="139.767125"
+      data-zoom="16"
+      data-geolonia-fork-me-disabled="on"
+      data-fullscreen-control="on"
+    ></div>
+  </div>
+
+  <script src="./embed.js?geolonia-api-key=YOUR-API-KEY"></script>
+</body>
+
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -16,7 +16,8 @@ pre
   background-color: #f5f5f5;
   border: 1px solid #dedede;
   margin: 1em 0;
-  white-space: pre-wrap ;
+  white-space: pre-wrap;
+  overflow-x: scroll;
 }
 
 footer

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -48,6 +48,12 @@ export default class GeoloniaMap extends mapboxgl.Map {
     let loading
     if ('off' !== atts.loader) {
       loading = document.createElement('div')
+      // prevent pinchin & pinchout
+      loading.addEventListener('touchmove', e => {
+        if (e.touches && 1 < e.touches.length) {
+          e.preventDefault()
+        }
+      })
       loading.className = 'loading-geolonia-map'
       loading.innerHTML = `<div class="lds-grid"><div></div><div></div><div></div>
           <div></div><div></div><div></div><div></div><div></div><div></div></div>`


### PR DESCRIPTION
無効化することで、特にスマートフォン向けに地図を画面いっぱいに表示している場合に意図せずズームしてしまう操作を防ぎます。
また、このような間違ったズームが発生すると全画面の地図であっても2本指操作が強制状態になるので、それを防ぎます。