### PR TITLE
Replace YOUR-API-KEY with registered key in tileserver requests

### DIFF
--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -75,6 +75,10 @@ export default class GeoloniaMap extends mapboxgl.Map {
         return {
           url: sourcesUrl.toString(),
         }
+      } else if (resourceType === 'Source' && url.startsWith('https://tileserver.geolonia.com')) {
+        return {
+          url: url.replace('YOUR-API-KEY', atts.key),
+        }
       }
 
       let request


### PR DESCRIPTION
tileserver.geolonia.com を直接使う場合、`style.json` にハードコードされた api key を data-key で動的に使えるようになる