### PR TITLE
Add simple vector

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -325,6 +325,18 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
   </div>
 
   <div class="example">
+    <h2>Vector Tile with SimpleStyle</h2>
+    <div
+      class="geolonia"
+      data-lat="35.67436"
+      data-lng="139.75595"
+      data-zoom="15"
+      data-simple-vector="https://tileserver-dev.geolonia.com/embed-simple-vector-sample/tiles.json?key=YOUR-API-KEY"
+      data-marker="off"
+    ></div>
+  </div>
+
+  <div class="example">
     <h2>i18n</h2>
     <div
       class="geolonia"

--- a/docs/index.html
+++ b/docs/index.html
@@ -331,7 +331,7 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
       data-lat="35.67436"
       data-lng="139.75595"
       data-zoom="15"
-      data-simple-vector="https://tileserver-dev.geolonia.com/embed-simple-vector-sample/tiles.json?key=YOUR-API-KEY"
+      data-simple-vector="https://tileserver.geolonia.com/embed-simple-vector-sample/tiles.json?key=YOUR-API-KEY"
       data-marker="off"
     ></div>
   </div>

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -4,6 +4,7 @@ import mapboxgl from 'mapbox-gl'
 import GeoloniaControl from '@geolonia/mbgl-geolonia-control'
 import GestureHandling from '@geolonia/mbgl-gesture-handling'
 import simpleStyle from './simplestyle'
+import simpleStyleVector from './simplestyle-vector'
 import parseAtts from './parse-atts'
 
 import * as util from './util'
@@ -220,6 +221,10 @@ export default class GeoloniaMap extends mapboxgl.Map {
             }).addTo(map)
           })
         }
+      }
+
+      if (atts.simpleVector) {
+        new simpleStyleVector(atts.simpleVector).addTo(map)
       }
 
       if (atts['3d']) {

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -203,6 +203,10 @@ export default class GeoloniaMap extends mapboxgl.Map {
         }
       }
 
+      if (atts.simpleVector) {
+        new SimpleStyleVector(atts.simpleVector).addTo(map)
+      }
+
       if (atts.geojson) {
         const el = isCssSelector(atts.geojson)
         if (el) {
@@ -221,10 +225,6 @@ export default class GeoloniaMap extends mapboxgl.Map {
             }).addTo(map)
           })
         }
-      }
-
-      if (atts.simpleVector) {
-        new SimpleStyleVector(atts.simpleVector).addTo(map)
       }
 
       if (atts['3d']) {

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -224,11 +224,7 @@ export default class GeoloniaMap extends mapboxgl.Map {
       }
 
       if (atts.simpleVector) {
-        fetch(atts.simpleVector).then(response => {
-          return response.json()
-        }).then(tileJson => {
-          new simpleStyleVector(atts.simpleVector,tileJson).addTo(map)
-        })
+        new simpleStyleVector(atts.simpleVector).addTo(map)
       }
 
       if (atts['3d']) {

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -3,8 +3,8 @@ import 'promise-polyfill/src/polyfill'
 import mapboxgl from 'mapbox-gl'
 import GeoloniaControl from '@geolonia/mbgl-geolonia-control'
 import GestureHandling from '@geolonia/mbgl-gesture-handling'
-import simpleStyle from './simplestyle'
-import simpleStyleVector from './simplestyle-vector'
+import SimpleStyle from './simplestyle'
+import SimpleStyleVector from './simplestyle-vector'
 import parseAtts from './parse-atts'
 
 import * as util from './util'
@@ -207,7 +207,7 @@ export default class GeoloniaMap extends mapboxgl.Map {
         const el = isCssSelector(atts.geojson)
         if (el) {
           const json = JSON.parse(el.textContent)
-          new simpleStyle(json, {
+          new SimpleStyle(json, {
             cluster: ('on' === atts.cluster),
             clusterColor: atts.clusterColor,
           }).addTo(map)
@@ -215,7 +215,7 @@ export default class GeoloniaMap extends mapboxgl.Map {
           fetch(atts.geojson).then(response => {
             return response.json()
           }).then(json => {
-            new simpleStyle(json, {
+            new SimpleStyle(json, {
               cluster: ('on' === atts.cluster),
               clusterColor: atts.clusterColor,
             }).addTo(map)
@@ -224,7 +224,7 @@ export default class GeoloniaMap extends mapboxgl.Map {
       }
 
       if (atts.simpleVector) {
-        new simpleStyleVector(atts.simpleVector).addTo(map)
+        new SimpleStyleVector(atts.simpleVector).addTo(map)
       }
 
       if (atts['3d']) {

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -224,7 +224,11 @@ export default class GeoloniaMap extends mapboxgl.Map {
       }
 
       if (atts.simpleVector) {
-        new simpleStyleVector(atts.simpleVector).addTo(map)
+        fetch(atts.simpleVector).then(response => {
+          return response.json()
+        }).then(tileJson => {
+          new simpleStyleVector(atts.simpleVector,tileJson).addTo(map)
+        })
       }
 
       if (atts['3d']) {

--- a/src/lib/parse-atts.js
+++ b/src/lib/parse-atts.js
@@ -40,6 +40,7 @@ export default (container, params = {}) => {
     scaleControl: 'off',
     geoloniaControl: 'on',
     geojson: '',
+    simpleVector: '',
     cluster: 'on',
     clusterColor: '#ff0000',
     style: 'geolonia/basic',

--- a/src/lib/parse-atts.test.js
+++ b/src/lib/parse-atts.test.js
@@ -38,6 +38,7 @@ describe('tests for parse Attributes', () => {
       scaleControl: 'off',
       geoloniaControl: 'on',
       geojson: '',
+      simpleVector: '',
       cluster: 'on',
       clusterColor: '#ff0000',
       style: 'geolonia/basic',

--- a/src/lib/simplestyle-vector.js
+++ b/src/lib/simplestyle-vector.js
@@ -11,59 +11,66 @@ const backgroundColor = 'rgba(255, 0, 0, 0.4)'
 const strokeColor = '#FFFFFF'
 
 class simpleStyleVector {
-  constructor(json) {
-    this.json = json
+  constructor(url, tileJson) {
+    this.url = url
+    this.tileJson = tileJson
   }
 
   addTo(map) {
     map.addSource('vt-geolonia-simple-style', {
       "type": "vector",
-      "url": this.json
+      "url": this.url
     })
 
-    this.setPolygonGeometries(map)
-    this.setLineGeometries(map)
+    this.tileJson.vector_layers.forEach(layer => {
 
-    map.addLayer({
-      id: 'vt-geolonia-simple-style-polygon-symbol',
-      type: 'symbol',
-      source: 'vt-geolonia-simple-style',
-      filter: ['==', '$type', 'Polygon'],
-      paint: {
-        'text-color': ['string', ['get', 'text-color'], textColor],
-        'text-halo-color': ['string', ['get', 'text-halo-color'], textHaloColor],
-        'text-halo-width': 1,
-      },
-      layout: {
-        'text-field': ['get', 'title'],
-        'text-font': ['Noto Sans Regular'],
-        'text-size': 12,
-        'text-max-width': 12,
-        'text-allow-overlap': false,
-      },
-    })
-
-    map.addLayer({
-      id: 'vt-geolonia-simple-style-linestring-symbol',
-      type: 'symbol',
-      source: 'vt-geolonia-simple-style',
-      filter: ['==', '$type', 'LineString'],
-      paint: {
-        'text-color': ['string', ['get', 'text-color'], textColor],
-        'text-halo-color': ['string', ['get', 'text-halo-color'], textHaloColor],
-        'text-halo-width': 1,
-      },
-      layout: {
-        'symbol-placement': 'line',
-        'text-field': ['get', 'title'],
-        'text-font': ['Noto Sans Regular'],
-        'text-size': 12,
-        'text-max-width': 12,
-        'text-allow-overlap': false,
-      },
-    })
-
-    this.setPointGeometries(map)
+      this.setPolygonGeometries(map, layer)
+      this.setLineGeometries(map, layer)
+  
+      map.addLayer({
+        id: 'vt-geolonia-simple-style-polygon-symbol',
+        type: 'symbol',
+        source: 'vt-geolonia-simple-style',
+        'source-layer': layer.id,
+        filter: ['==', '$type', 'Polygon'],
+        paint: {
+          'text-color': ['string', ['get', 'text-color'], textColor],
+          'text-halo-color': ['string', ['get', 'text-halo-color'], textHaloColor],
+          'text-halo-width': 1,
+        },
+        layout: {
+          'text-field': ['get', 'title'],
+          'text-font': ['Noto Sans Regular'],
+          'text-size': 12,
+          'text-max-width': 12,
+          'text-allow-overlap': false,
+        },
+      })
+  
+      map.addLayer({
+        id: 'vt-geolonia-simple-style-linestring-symbol',
+        type: 'symbol',
+        source: 'vt-geolonia-simple-style',
+        'source-layer': layer.id,
+        filter: ['==', '$type', 'LineString'],
+        paint: {
+          'text-color': ['string', ['get', 'text-color'], textColor],
+          'text-halo-color': ['string', ['get', 'text-halo-color'], textHaloColor],
+          'text-halo-width': 1,
+        },
+        layout: {
+          'symbol-placement': 'line',
+          'text-field': ['get', 'title'],
+          'text-font': ['Noto Sans Regular'],
+          'text-size': 12,
+          'text-max-width': 12,
+          'text-allow-overlap': false,
+        },
+      })
+  
+      this.setPointGeometries(map, layer)
+  
+    });
 
     const container = map.getContainer()
 
@@ -81,11 +88,12 @@ class simpleStyleVector {
    *
    * @param map
    */
-  setPolygonGeometries(map) {
+  setPolygonGeometries(map, layer) {
     map.addLayer({
       id: 'vt-geolonia-simple-style-polygon',
       type: 'fill',
       source: 'vt-geolonia-simple-style',
+      'source-layer': layer.id,
       filter: ['==', '$type', 'Polygon'],
       paint: {
         'fill-color': ['string', ['get', 'fill'], backgroundColor],
@@ -102,11 +110,12 @@ class simpleStyleVector {
    *
    * @param map
    */
-  setLineGeometries(map) {
+  setLineGeometries(map, layer) {
     map.addLayer({
       id: 'vt-geolonia-simple-style-linestring',
       type: 'line',
       source: 'vt-geolonia-simple-style',
+      'source-layer': layer.id,
       filter: ['==', '$type', 'LineString'],
       paint: {
         'line-width': ['number', ['get', 'stroke-width'], 2],
@@ -127,11 +136,12 @@ class simpleStyleVector {
    *
    * @param map
    */
-  setPointGeometries(map) {
+  setPointGeometries(map, layer) {
     map.addLayer({
       id: 'vt-circle-simple-style-points',
       type: 'circle',
       source: 'vt-geolonia-simple-style',
+      'source-layer': layer.id,
       filter: ['!', ['has', 'point_count']],
       paint: {
         'circle-radius': [
@@ -152,6 +162,7 @@ class simpleStyleVector {
       id: 'vt-geolonia-simple-style-points',
       type: 'symbol',
       source: 'vt-geolonia-simple-style',
+      'source-layer': layer.id,
       filter: ['!', ['has', 'point_count']],
       paint: {
         'text-color': ['string', ['get', 'text-color'], textColor],

--- a/src/lib/simplestyle-vector.js
+++ b/src/lib/simplestyle-vector.js
@@ -1,0 +1,208 @@
+'use strict'
+
+import mapboxgl from 'mapbox-gl'
+import geojsonExtent from '@mapbox/geojson-extent'
+import turfCenter from '@turf/center'
+import sanitizeHtml from 'sanitize-html'
+
+const textColor = '#000000'
+const textHaloColor = '#FFFFFF'
+const backgroundColor = 'rgba(255, 0, 0, 0.4)'
+const strokeColor = '#FFFFFF'
+
+class simpleStyleVector {
+  constructor(json) {
+    this.json = json
+  }
+
+  addTo(map) {
+
+    map.addSource('vt-geolonia-simple-style', {
+      "type": "vector",
+      "url": json
+    })
+
+    this.setPolygonGeometries(map)
+    this.setLineGeometries(map)
+
+    map.addLayer({
+      id: 'vt-geolonia-simple-style-polygon-symbol',
+      type: 'symbol',
+      source: 'vt-geolonia-simple-style',
+      filter: ['==', '$type', 'Polygon'],
+      paint: {
+        'text-color': ['string', ['get', 'text-color'], textColor],
+        'text-halo-color': ['string', ['get', 'text-halo-color'], textHaloColor],
+        'text-halo-width': 1,
+      },
+      layout: {
+        'text-field': ['get', 'title'],
+        'text-font': ['Noto Sans Regular'],
+        'text-size': 12,
+        'text-max-width': 12,
+        'text-allow-overlap': false,
+      },
+    })
+
+    map.addLayer({
+      id: 'vt-geolonia-simple-style-linestring-symbol',
+      type: 'symbol',
+      source: 'vt-geolonia-simple-style',
+      filter: ['==', '$type', 'LineString'],
+      paint: {
+        'text-color': ['string', ['get', 'text-color'], textColor],
+        'text-halo-color': ['string', ['get', 'text-halo-color'], textHaloColor],
+        'text-halo-width': 1,
+      },
+      layout: {
+        'symbol-placement': 'line',
+        'text-field': ['get', 'title'],
+        'text-font': ['Noto Sans Regular'],
+        'text-size': 12,
+        'text-max-width': 12,
+        'text-allow-overlap': false,
+      },
+    })
+
+    this.setPointGeometries(map)
+
+    const container = map.getContainer()
+
+    if (!container.dataset || (!container.dataset.lng && !container.dataset.lat)) {
+      const bounds = geojsonExtent(this.json)
+      map.fitBounds(bounds, {
+        duration: 0,
+        padding: 30,
+      })
+    }
+  }
+
+  /**
+   * Set polygon geometries.
+   *
+   * @param map
+   */
+  setPolygonGeometries(map) {
+    map.addLayer({
+      id: 'vt-geolonia-simple-style-polygon',
+      type: 'fill',
+      source: 'vt-geolonia-simple-style',
+      filter: ['==', '$type', 'Polygon'],
+      paint: {
+        'fill-color': ['string', ['get', 'fill'], backgroundColor],
+        'fill-opacity': ['number', ['get', 'fill-opacity'], 1.0],
+        'fill-outline-color': ['string', ['get', 'stroke'], strokeColor],
+      },
+    })
+
+    this.setPopup(map, 'vt-geolonia-simple-style-polygon')
+  }
+
+  /**
+   * Set line geometries.
+   *
+   * @param map
+   */
+  setLineGeometries(map) {
+    map.addLayer({
+      id: 'vt-geolonia-simple-style-linestring',
+      type: 'line',
+      source: 'vt-geolonia-simple-style',
+      filter: ['==', '$type', 'LineString'],
+      paint: {
+        'line-width': ['number', ['get', 'stroke-width'], 2],
+        'line-color': ['string', ['get', 'stroke'], backgroundColor],
+        'line-opacity': ['number', ['get', 'stroke-opacity'], 1.0],
+      },
+      layout: {
+        'line-cap': 'round',
+        'line-join': 'round',
+      },
+    })
+
+    this.setPopup(map, 'vt-geolonia-simple-style-linestring')
+  }
+
+  /**
+   * Setup point geometries.
+   *
+   * @param map
+   */
+  setPointGeometries(map) {
+    map.addLayer({
+      id: 'vt-circle-simple-style-points',
+      type: 'circle',
+      source: 'vt-geolonia-simple-style-points',
+      filter: ['!', ['has', 'point_count']],
+      paint: {
+        'circle-radius': [
+          'case',
+          ['==', 'small', ['get', 'marker-size']], 7,
+          ['==', 'large', ['get', 'marker-size']], 13,
+          9,
+        ],
+        'circle-color': ['string', ['get', 'marker-color'], backgroundColor],
+        'circle-opacity': ['number', ['get', 'fill-opacity'], 1.0],
+        'circle-stroke-width': ['number', ['get', 'stroke-width'], 1],
+        'circle-stroke-color': ['string', ['get', 'stroke'], strokeColor],
+        'circle-stroke-opacity': ['number', ['get', 'stroke-opacity'], 1.0],
+      },
+    })
+
+    map.addLayer({
+      id: 'vt-symbol-simple-style-points',
+      type: 'symbol',
+      source: 'vt-geolonia-simple-style-points',
+      filter: ['!', ['has', 'point_count']],
+      paint: {
+        'text-color': ['string', ['get', 'text-color'], textColor],
+        'text-halo-color': ['string', ['get', 'text-halo-color'], textHaloColor],
+        'text-halo-width': 1,
+      },
+      layout: {
+        'icon-image': [
+          'case',
+          ['==', 'large', ['get', 'marker-size']], ['image', ['concat', ['get', 'marker-symbol'], '-15']],
+          ['image', ['concat', ['get', 'marker-symbol'], '-11']],
+        ],
+        'text-field': ['get', 'title'],
+        'text-font': ['Noto Sans Regular'],
+        'text-size': 12,
+        'text-anchor': 'top',
+        'text-max-width': 12,
+        'text-offset': [
+          'case',
+          ['==', 'small', ['get', 'marker-size']], ['literal', [0, 0.6]],
+          ['==', 'large', ['get', 'marker-size']], ['literal', [0, 1.2]],
+          ['literal', [0, 0.8]],
+        ],
+        'text-allow-overlap': false,
+      },
+    })
+
+    this.setPopup(map, 'vt-circle-simple-style-points')
+  }
+
+  setPopup(map, source) {
+    map.on('click', source, e => {
+      const center = turfCenter(e.features[0]).geometry.coordinates
+      const description = e.features[0].properties.description
+
+      if (description) {
+        new mapboxgl.Popup().setLngLat(center).setHTML(sanitizeHtml(description)).addTo(map)
+      }
+    })
+
+    map.on('mouseenter', source, e => {
+      if (e.features[0].properties.description) {
+        map.getCanvas().style.cursor = 'pointer'
+      }
+    })
+
+    map.on('mouseleave', source, () => {
+      map.getCanvas().style.cursor = ''
+    })
+  }
+}
+
+export default simpleStyleVector

--- a/src/lib/simplestyle-vector.js
+++ b/src/lib/simplestyle-vector.js
@@ -11,9 +11,8 @@ const backgroundColor = 'rgba(255, 0, 0, 0.4)'
 const strokeColor = '#FFFFFF'
 
 class simpleStyleVector {
-  constructor(url, tileJson) {
+  constructor(url) {
     this.url = url
-    this.tileJson = tileJson
   }
 
   addTo(map) {
@@ -22,56 +21,52 @@ class simpleStyleVector {
       "url": this.url
     })
 
-    this.tileJson.vector_layers.forEach(layer => {
+    this.setPolygonGeometries(map)
+    this.setLineGeometries(map)
 
-      this.setPolygonGeometries(map, layer)
-      this.setLineGeometries(map, layer)
-  
-      map.addLayer({
-        id: 'vt-geolonia-simple-style-polygon-symbol',
-        type: 'symbol',
-        source: 'vt-geolonia-simple-style',
-        'source-layer': layer.id,
-        filter: ['==', '$type', 'Polygon'],
-        paint: {
-          'text-color': ['string', ['get', 'text-color'], textColor],
-          'text-halo-color': ['string', ['get', 'text-halo-color'], textHaloColor],
-          'text-halo-width': 1,
-        },
-        layout: {
-          'text-field': ['get', 'title'],
-          'text-font': ['Noto Sans Regular'],
-          'text-size': 12,
-          'text-max-width': 12,
-          'text-allow-overlap': false,
-        },
-      })
-  
-      map.addLayer({
-        id: 'vt-geolonia-simple-style-linestring-symbol',
-        type: 'symbol',
-        source: 'vt-geolonia-simple-style',
-        'source-layer': layer.id,
-        filter: ['==', '$type', 'LineString'],
-        paint: {
-          'text-color': ['string', ['get', 'text-color'], textColor],
-          'text-halo-color': ['string', ['get', 'text-halo-color'], textHaloColor],
-          'text-halo-width': 1,
-        },
-        layout: {
-          'symbol-placement': 'line',
-          'text-field': ['get', 'title'],
-          'text-font': ['Noto Sans Regular'],
-          'text-size': 12,
-          'text-max-width': 12,
-          'text-allow-overlap': false,
-        },
-      })
-  
-      this.setPointGeometries(map, layer)
-  
-    });
+    map.addLayer({
+      id: 'vt-geolonia-simple-style-polygon-symbol',
+      type: 'symbol',
+      source: 'vt-geolonia-simple-style',
+      'source-layer': 'vtGeoloniaSimpleStyle',
+      filter: ['==', '$type', 'Polygon'],
+      paint: {
+        'text-color': ['string', ['get', 'text-color'], textColor],
+        'text-halo-color': ['string', ['get', 'text-halo-color'], textHaloColor],
+        'text-halo-width': 1,
+      },
+      layout: {
+        'text-field': ['get', 'title'],
+        'text-font': ['Noto Sans Regular'],
+        'text-size': 12,
+        'text-max-width': 12,
+        'text-allow-overlap': false,
+      },
+    })
 
+    map.addLayer({
+      id: 'vt-geolonia-simple-style-linestring-symbol',
+      type: 'symbol',
+      source: 'vt-geolonia-simple-style',
+      'source-layer': 'vtGeoloniaSimpleStyle',
+      filter: ['==', '$type', 'LineString'],
+      paint: {
+        'text-color': ['string', ['get', 'text-color'], textColor],
+        'text-halo-color': ['string', ['get', 'text-halo-color'], textHaloColor],
+        'text-halo-width': 1,
+      },
+      layout: {
+        'symbol-placement': 'line',
+        'text-field': ['get', 'title'],
+        'text-font': ['Noto Sans Regular'],
+        'text-size': 12,
+        'text-max-width': 12,
+        'text-allow-overlap': false,
+      },
+    })
+
+    this.setPointGeometries(map)
+  
     const container = map.getContainer()
 
     if (!container.dataset || (!container.dataset.lng && !container.dataset.lat)) {
@@ -88,12 +83,12 @@ class simpleStyleVector {
    *
    * @param map
    */
-  setPolygonGeometries(map, layer) {
+  setPolygonGeometries(map) {
     map.addLayer({
       id: 'vt-geolonia-simple-style-polygon',
       type: 'fill',
       source: 'vt-geolonia-simple-style',
-      'source-layer': layer.id,
+      'source-layer': 'vtGeoloniaSimpleStyle',
       filter: ['==', '$type', 'Polygon'],
       paint: {
         'fill-color': ['string', ['get', 'fill'], backgroundColor],
@@ -110,12 +105,12 @@ class simpleStyleVector {
    *
    * @param map
    */
-  setLineGeometries(map, layer) {
+  setLineGeometries(map) {
     map.addLayer({
       id: 'vt-geolonia-simple-style-linestring',
       type: 'line',
       source: 'vt-geolonia-simple-style',
-      'source-layer': layer.id,
+      'source-layer': 'vtGeoloniaSimpleStyle',
       filter: ['==', '$type', 'LineString'],
       paint: {
         'line-width': ['number', ['get', 'stroke-width'], 2],
@@ -136,12 +131,12 @@ class simpleStyleVector {
    *
    * @param map
    */
-  setPointGeometries(map, layer) {
+  setPointGeometries(map) {
     map.addLayer({
       id: 'vt-circle-simple-style-points',
       type: 'circle',
       source: 'vt-geolonia-simple-style',
-      'source-layer': layer.id,
+      'source-layer': 'vtGeoloniaSimpleStyle',
       filter: ['!', ['has', 'point_count']],
       paint: {
         'circle-radius': [
@@ -162,7 +157,7 @@ class simpleStyleVector {
       id: 'vt-geolonia-simple-style-points',
       type: 'symbol',
       source: 'vt-geolonia-simple-style',
-      'source-layer': layer.id,
+      'source-layer': 'vtGeoloniaSimpleStyle',
       filter: ['!', ['has', 'point_count']],
       paint: {
         'text-color': ['string', ['get', 'text-color'], textColor],

--- a/src/lib/simplestyle-vector.js
+++ b/src/lib/simplestyle-vector.js
@@ -28,7 +28,7 @@ class SimpleStyleVector {
       id: 'vt-geolonia-simple-style-polygon-symbol',
       type: 'symbol',
       source: 'vt-geolonia-simple-style',
-      'source-layer': 'vtGeoloniaSimpleStyle',
+      'source-layer': 'geolonia',
       filter: ['==', '$type', 'Polygon'],
       paint: {
         'text-color': ['string', ['get', 'text-color'], textColor],
@@ -48,7 +48,7 @@ class SimpleStyleVector {
       id: 'vt-geolonia-simple-style-linestring-symbol',
       type: 'symbol',
       source: 'vt-geolonia-simple-style',
-      'source-layer': 'vtGeoloniaSimpleStyle',
+      'source-layer': 'geolonia',
       filter: ['==', '$type', 'LineString'],
       paint: {
         'text-color': ['string', ['get', 'text-color'], textColor],
@@ -88,7 +88,7 @@ class SimpleStyleVector {
       id: 'vt-geolonia-simple-style-polygon',
       type: 'fill',
       source: 'vt-geolonia-simple-style',
-      'source-layer': 'vtGeoloniaSimpleStyle',
+      'source-layer': 'geolonia',
       filter: ['==', '$type', 'Polygon'],
       paint: {
         'fill-color': ['string', ['get', 'fill'], backgroundColor],
@@ -110,7 +110,7 @@ class SimpleStyleVector {
       id: 'vt-geolonia-simple-style-linestring',
       type: 'line',
       source: 'vt-geolonia-simple-style',
-      'source-layer': 'vtGeoloniaSimpleStyle',
+      'source-layer': 'geolonia',
       filter: ['==', '$type', 'LineString'],
       paint: {
         'line-width': ['number', ['get', 'stroke-width'], 2],
@@ -136,7 +136,7 @@ class SimpleStyleVector {
       id: 'vt-circle-simple-style-points',
       type: 'circle',
       source: 'vt-geolonia-simple-style',
-      'source-layer': 'vtGeoloniaSimpleStyle',
+      'source-layer': 'geolonia',
       filter: ['==', '$type', 'Point'],
       paint: {
         'circle-radius': [
@@ -157,7 +157,7 @@ class SimpleStyleVector {
       id: 'vt-geolonia-simple-style-points',
       type: 'symbol',
       source: 'vt-geolonia-simple-style',
-      'source-layer': 'vtGeoloniaSimpleStyle',
+      'source-layer': 'geolonia',
       filter: ['==', '$type', 'Point'],
       paint: {
         'text-color': ['string', ['get', 'text-color'], textColor],

--- a/src/lib/simplestyle-vector.js
+++ b/src/lib/simplestyle-vector.js
@@ -28,7 +28,7 @@ class SimpleStyleVector {
       id: 'vt-geolonia-simple-style-polygon-symbol',
       type: 'symbol',
       source: 'vt-geolonia-simple-style',
-      'source-layer': 'geolonia',
+      'source-layer': 'g-simplestyle-v1',
       filter: ['==', '$type', 'Polygon'],
       paint: {
         'text-color': ['string', ['get', 'text-color'], textColor],
@@ -48,7 +48,7 @@ class SimpleStyleVector {
       id: 'vt-geolonia-simple-style-linestring-symbol',
       type: 'symbol',
       source: 'vt-geolonia-simple-style',
-      'source-layer': 'geolonia',
+      'source-layer': 'g-simplestyle-v1',
       filter: ['==', '$type', 'LineString'],
       paint: {
         'text-color': ['string', ['get', 'text-color'], textColor],
@@ -88,7 +88,7 @@ class SimpleStyleVector {
       id: 'vt-geolonia-simple-style-polygon',
       type: 'fill',
       source: 'vt-geolonia-simple-style',
-      'source-layer': 'geolonia',
+      'source-layer': 'g-simplestyle-v1',
       filter: ['==', '$type', 'Polygon'],
       paint: {
         'fill-color': ['string', ['get', 'fill'], backgroundColor],
@@ -110,7 +110,7 @@ class SimpleStyleVector {
       id: 'vt-geolonia-simple-style-linestring',
       type: 'line',
       source: 'vt-geolonia-simple-style',
-      'source-layer': 'geolonia',
+      'source-layer': 'g-simplestyle-v1',
       filter: ['==', '$type', 'LineString'],
       paint: {
         'line-width': ['number', ['get', 'stroke-width'], 2],
@@ -136,7 +136,7 @@ class SimpleStyleVector {
       id: 'vt-circle-simple-style-points',
       type: 'circle',
       source: 'vt-geolonia-simple-style',
-      'source-layer': 'geolonia',
+      'source-layer': 'g-simplestyle-v1',
       filter: ['==', '$type', 'Point'],
       paint: {
         'circle-radius': [
@@ -157,7 +157,7 @@ class SimpleStyleVector {
       id: 'vt-geolonia-simple-style-points',
       type: 'symbol',
       source: 'vt-geolonia-simple-style',
-      'source-layer': 'geolonia',
+      'source-layer': 'g-simplestyle-v1',
       filter: ['==', '$type', 'Point'],
       paint: {
         'text-color': ['string', ['get', 'text-color'], textColor],

--- a/src/lib/simplestyle-vector.js
+++ b/src/lib/simplestyle-vector.js
@@ -10,7 +10,7 @@ const textHaloColor = '#FFFFFF'
 const backgroundColor = 'rgba(255, 0, 0, 0.4)'
 const strokeColor = '#FFFFFF'
 
-class simpleStyleVector {
+class SimpleStyleVector {
   constructor(url) {
     this.url = url
   }
@@ -210,4 +210,4 @@ class simpleStyleVector {
   }
 }
 
-export default simpleStyleVector
+export default SimpleStyleVector

--- a/src/lib/simplestyle-vector.js
+++ b/src/lib/simplestyle-vector.js
@@ -16,10 +16,9 @@ class simpleStyleVector {
   }
 
   addTo(map) {
-
     map.addSource('vt-geolonia-simple-style', {
       "type": "vector",
-      "url": json
+      "url": this.json
     })
 
     this.setPolygonGeometries(map)
@@ -132,7 +131,7 @@ class simpleStyleVector {
     map.addLayer({
       id: 'vt-circle-simple-style-points',
       type: 'circle',
-      source: 'vt-geolonia-simple-style-points',
+      source: 'vt-geolonia-simple-style',
       filter: ['!', ['has', 'point_count']],
       paint: {
         'circle-radius': [
@@ -150,9 +149,9 @@ class simpleStyleVector {
     })
 
     map.addLayer({
-      id: 'vt-symbol-simple-style-points',
+      id: 'vt-geolonia-simple-style-points',
       type: 'symbol',
-      source: 'vt-geolonia-simple-style-points',
+      source: 'vt-geolonia-simple-style',
       filter: ['!', ['has', 'point_count']],
       paint: {
         'text-color': ['string', ['get', 'text-color'], textColor],

--- a/src/lib/simplestyle-vector.js
+++ b/src/lib/simplestyle-vector.js
@@ -17,8 +17,8 @@ class SimpleStyleVector {
 
   addTo(map) {
     map.addSource('vt-geolonia-simple-style', {
-      "type": "vector",
-      "url": this.url
+      type: 'vector',
+      url: this.url,
     })
 
     this.setPolygonGeometries(map)

--- a/src/lib/simplestyle-vector.js
+++ b/src/lib/simplestyle-vector.js
@@ -137,7 +137,7 @@ class SimpleStyleVector {
       type: 'circle',
       source: 'vt-geolonia-simple-style',
       'source-layer': 'vtGeoloniaSimpleStyle',
-      filter: ['!', ['has', 'point_count']],
+      filter: ['==', '$type', 'Point'],
       paint: {
         'circle-radius': [
           'case',
@@ -158,7 +158,7 @@ class SimpleStyleVector {
       type: 'symbol',
       source: 'vt-geolonia-simple-style',
       'source-layer': 'vtGeoloniaSimpleStyle',
-      filter: ['!', ['has', 'point_count']],
+      filter: ['==', '$type', 'Point'],
       paint: {
         'text-color': ['string', ['get', 'text-color'], textColor],
         'text-halo-color': ['string', ['get', 'text-halo-color'], textHaloColor],

--- a/src/lib/simplestyle.js
+++ b/src/lib/simplestyle.js
@@ -10,7 +10,7 @@ const textHaloColor = '#FFFFFF'
 const backgroundColor = 'rgba(255, 0, 0, 0.4)'
 const strokeColor = '#FFFFFF'
 
-class simpleStyle {
+class SimpleStyle {
   constructor(json, options) {
     this.json = json
 
@@ -283,4 +283,4 @@ class simpleStyle {
   }
 }
 
-export default simpleStyle
+export default SimpleStyle


### PR DESCRIPTION
Closes #212 

修正内容

- `data-simple-vector`属性を追加
- ベクトルタイル用のスタイルを `simplestyle-vector.js` に追加
  -  `'source-layer` は ~~`vtGeoloniaSimpleStyle`~~ `geolonia` で固定
-  SimpleStyle の頭文字を大文字に変更

プレビュー環境
https://deploy-preview-213--geolonia-embed.netlify.app/#:~:text=Vector%20Tile%20with%20SimpleStyle