### PR TITLE
Reattach style extensions after setStyle()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@geolonia/embed",
-      "version": "1.16.1",
+      "version": "1.17.0",
       "license": "MIT",
       "dependencies": {
         "@geolonia/mbgl-geolonia-control": "^0.4.0",

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -211,12 +211,13 @@ export default class GeoloniaMap extends mapboxgl.Map {
     })
 
     map.on('styledata', event => {
+      const map = event.target
+
       if (!this.__styleExtensionLoadRequired) {
         return
       }
       this.__styleExtensionLoadRequired = false
 
-      const map = event.target
       if (atts.simpleVector) {
         new SimpleStyleVector(atts.simpleVector).addTo(map)
       }


### PR DESCRIPTION
`map.setStyle(...)` で Simplestyle GeoJSON, Simplestyle Vector Tiles, 3D の表示がなくなるバグの修正です

`map.on("styledata", ...` のコールバックはスタイル更新が行った度に呼び出されるので、ループによるエラーを防ぐために `__styleExtensionLoadRequired` のフラグを使っています。もしもっと良いのがあれば教えてください :bow: