### PR TITLE
data-simple-vector 拡張

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ typings/
 # Others
 /dist
 /docs/embed.js
+/docs/v1/embed.js
 /snapshots
 .cache
 .DS_Store

--- a/docs/index.html
+++ b/docs/index.html
@@ -329,7 +329,6 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
     <div
       class="geolonia"
       data-simple-vector="https://tileserver.geolonia.com/embed-simple-vector-sample/tiles.json"
-      data-marker="off"
     ></div>
   </div>
 
@@ -338,7 +337,6 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
     <div
       class="geolonia"
       data-simple-vector="geolonia://tiles/geolonia/2743bbe4da254ab2b6a6477129203d60"
-      data-marker="off"
     ></div>
   </div>
 
@@ -347,7 +345,6 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
     <div
       class="geolonia"
       data-simple-vector="2743bbe4da254ab2b6a6477129203d60"
-      data-marker="off"
     ></div>
   </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -328,7 +328,25 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
     <h2>Vector Tile with SimpleStyle</h2>
     <div
       class="geolonia"
-      data-simple-vector="https://tileserver.geolonia.com/embed-simple-vector-sample/tiles.json?key=YOUR-API-KEY"
+      data-simple-vector="https://tileserver.geolonia.com/embed-simple-vector-sample/tiles.json"
+      data-marker="off"
+    ></div>
+  </div>
+
+  <div class="example">
+    <h2>Vector Tile with geolonia:// scheme</h2>
+    <div
+      class="geolonia"
+      data-simple-vector="geolonia://tiles/geolonia/2743bbe4da254ab2b6a6477129203d60"
+      data-marker="off"
+    ></div>
+  </div>
+
+  <div class="example">
+    <h2>Vector Tile with customtile ID</h2>
+    <div
+      class="geolonia"
+      data-simple-vector="2743bbe4da254ab2b6a6477129203d60"
       data-marker="off"
     ></div>
   </div>

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -219,7 +219,8 @@ export default class GeoloniaMap extends mapboxgl.Map {
       this.__styleExtensionLoadRequired = false
 
       if (atts.simpleVector) {
-        new SimpleStyleVector(atts.simpleVector).addTo(map)
+        const simpleVectorAttributeValue = util.parseSimpleVector(atts.simpleVector, atts.customtileUrl)
+        new SimpleStyleVector(simpleVectorAttributeValue).addTo(map)
       }
 
       if (atts.geojson) {

--- a/src/lib/parse-atts.js
+++ b/src/lib/parse-atts.js
@@ -48,6 +48,7 @@ export default (container, params = {}) => {
     plugin: 'off',
     key: key,
     apiUrl: `https://api.geolonia.com/${stage}`,
+    customtileUrl: stage === 'v1' ? 'https://tileserver.geolonia.com' : `https://tileserver-${stage}.geolonia.com`,
     loader: 'on',
     minZoom: '',
     maxZoom: 20,

--- a/src/lib/parse-atts.test.js
+++ b/src/lib/parse-atts.test.js
@@ -46,6 +46,7 @@ describe('tests for parse Attributes', () => {
       plugin: 'off',
       key: 'YOUR-API-KEY',
       apiUrl: 'https://api.geolonia.com/v1',
+      customtileUrl: 'https://tileserver.geolonia.com',
       loader: 'on',
       minZoom: '',
       maxZoom: 20,

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -215,7 +215,7 @@ export function getOptions(container, params, atts) {
 }
 
 /**
- * 
+ *
  * @param {string} an data-*-control Embed attribute
  * @returns { enabled: bolean, position: 'top-right' | 'bottom-right' | 'bottom-left' | 'top-left' | void }
  */
@@ -236,7 +236,7 @@ export function parseControlOption(att) {
 let sessionId = ''
 
 /**
- * 
+ *
  * @param {number} digits for session
  * @returns sessionId
  */
@@ -251,5 +251,19 @@ export const getSessionId = digit => {
       .join('')
     sessionId = value
     return value
+  }
+}
+
+export const parseSimpleVector = (attributeValue, customtileUrl) => {
+  if (/^https?:\/\//.test(attributeValue)) {
+    return attributeValue
+  } else {
+    const match = attributeValue.match(/^geolonia:\/\/tiles\/(?<username>.+)\/(?<customtileId>.+)/)
+    if (match) {
+      return `${customtileUrl}/customtiles/${match.groups.customtileId}/tiles.json`
+    } else {
+      // TODO: inject dev
+      return `${customtileUrl}/customtiles/${attributeValue}/tiles.json`
+    }
   }
 }

--- a/src/lib/util.test.js
+++ b/src/lib/util.test.js
@@ -171,4 +171,35 @@ describe('Tests for util.js', () => {
     assert.strictEqual(false, enabled)
     assert.strictEqual(void 0, position)
   })
+
+  it('should parse simple vector value with http.', () => {
+    const attributeValue = 'https://example.com/path/to/tile.json'
+    assert.strictEqual(
+      attributeValue,
+      util.parseSimpleVector(attributeValue),
+    )
+  })
+
+  it('should parse simple vector value with geolonia schema.', () => {
+    const attributeValue = 'geolonia://tiles/username/ct_123'
+    assert.strictEqual(
+      'https://tileserver.geolonia.com/customtiles/ct_123/tiles.json',
+      util.parseSimpleVector(attributeValue, 'https://tileserver.geolonia.com'),
+    )
+  })
+
+  it('should parse simple vector value with customtile ID', () => {
+    const attributeValue = 'ct_123'
+    assert.strictEqual(
+      'https://tileserver.geolonia.com/customtiles/ct_123/tiles.json',
+      util.parseSimpleVector(attributeValue, 'https://tileserver.geolonia.com'),
+    )
+  })
+  it('should parse simple vector value with stage identifier', () => {
+    const attributeValue = 'ct_123'
+    assert.strictEqual(
+      'https://tileserver-test.geolonia.com/customtiles/ct_123/tiles.json',
+      util.parseSimpleVector(attributeValue, 'https://tileserver-test.geolonia.com'),
+    )
+  })
 })


### PR DESCRIPTION
geolonia:// スキーマとカスタムタイルID がパースされるように修正。

```html
<div
  class="geolonia"
  data-simple-vector="geolonia://tiles/geolonia/2743bbe4da254ab2b6a6477129203d60"
></div>
```

```html
<div
  class="geolonia"
  data-simple-vector="2743bbe4da254ab2b6a6477129203d60"
></div>
```