### PR TITLE
Fix types for `Map` and `Marker`

### DIFF
--- a/src/embed.d.ts
+++ b/src/embed.d.ts
@@ -1,7 +1,8 @@
 import * as maplibregl from 'maplibre-gl';
 
-export type Map = maplibregl.Map
-export type Marker = maplibregl.Marker
+export class Map extends maplibregl.Map {}
+export class Marker extends maplibregl.Marker {}
+
 export type EmbedAttributes = {
   lat: string;
   lng: string;
@@ -40,11 +41,11 @@ export type EmbedPlugin<PluginAttributes extends { [otherKey: string]: string } 
 declare global {
   interface Window {
     geolonia: {
-      accessToken: string
-      baseApiUrl: string
-      Map: Map
-      Marker: Marker
-      registerPlugin: (embedPlugin: EmbedPlugin) => void
+      accessToken: string;
+      baseApiUrl: string;
+      Map: typeof Map;
+      Marker: typeof Marker;
+      registerPlugin: (embedPlugin: EmbedPlugin) => void;
     }
   }
 }


### PR DESCRIPTION
window.geolonia.Map and window.geolonia.Marker are the class itself, not an instance of the class

```
interface Window {
  geolonia: {
    ...
    Map: Map
```

これは、 `window.geolonia.Map` が `Map` のインスタンスということみたいなので、現状の型定義は `window.geolonia.Map = new Map()` になってるようです。。 `typeof Map` を使うことによってクラス自体がここに入ってるよということを示します。

また、 `typeof Map` は `type Map = maplibregl.Map` には使えなかったので、現状に合わせて subclass であることにしました。(ちなみに、 `export type Map = typeof maplibregl.Map` でも行けるんですが、今後独自なオプションとか追加する可能性としてsubclassに変えました :bow: