### PR TITLE
Added simpleStyle.fitBounds()

### DIFF
--- a/docs/simplestyle.html
+++ b/docs/simplestyle.html
@@ -72,7 +72,7 @@
       id: 'test'
     })
 
-    ss.addTo(map)
+    ss.addTo(map).fitBounds()
 
     let i = 0;
 

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -207,21 +207,28 @@ export default class GeoloniaMap extends maplibregl.Map {
       if (atts.geojson) {
         const el = isCssSelector(atts.geojson);
         const { default: SimpleStyle } = await import('./simplestyle');
+        let ss;
         if (el) {
           const json = JSON.parse(el.textContent);
-          new SimpleStyle(json, {
+          ss = new SimpleStyle(json, {
             cluster: (atts.cluster === 'on'),
             clusterColor: atts.clusterColor,
-          }).addTo(map);
+          });
         } else {
           fetch(atts.geojson).then((response) => {
             return response.json();
           }).then((json) => {
-            new SimpleStyle(json, {
+            ss = new SimpleStyle(json, {
               cluster: (atts.cluster === 'on'),
               clusterColor: atts.clusterColor,
-            }).addTo(map);
+            });
           });
+        }
+
+        ss.addTo(map);
+
+        if (!container.dataset || (!container.dataset.lng && !container.dataset.lat)) {
+          ss.fitBounds();
         }
       }
 

--- a/src/lib/simplestyle.js
+++ b/src/lib/simplestyle.js
@@ -19,8 +19,6 @@ class SimpleStyle {
       cluster: true,
       heatmap: false, // TODO: It should support heatmap.
       clusterColor: '#ff0000',
-      duration: 3000,
-      padding: 30,
       ...options,
     };
   }
@@ -116,16 +114,19 @@ class SimpleStyle {
     this.setPointGeometries();
     this.setCluster();
 
-    const container = this.map.getContainer();
+    return this;
+  }
 
-    if (!container.dataset || (!container.dataset.lng && !container.dataset.lat)) {
-      const bounds = geojsonExtent(this.geojson);
-      if (bounds) {
-        this.map.fitBounds(bounds, {
-          duration: this.options.duration,
-          padding: this.options.padding,
-        });
-      }
+  fitBounds(options = {}) {
+    const _options = {
+      duration: 3000,
+      padding: 30,
+      ...options,
+    };
+
+    const bounds = geojsonExtent(this.geojson);
+    if (bounds) {
+      this.map.fitBounds(bounds, _options);
     }
 
     return this;

--- a/src/lib/simplestyle.test.js
+++ b/src/lib/simplestyle.test.js
@@ -73,7 +73,7 @@ describe('Tests for simpleStyle()', () => {
     const { default: simpleStyle } = await import('./simplestyle');
 
     const map = new Map();
-    new simpleStyle(geojson).addTo(map);
+    new simpleStyle(geojson).addTo(map).fitBounds();
 
     assert.deepEqual([ 'geolonia-simple-style', 'geolonia-simple-style-points' ], Object.keys(map.sources));
     assert.deepEqual(8, map.layers.length);
@@ -85,7 +85,7 @@ describe('Tests for simpleStyle()', () => {
     const { default: simpleStyle } = await import('./simplestyle');
 
     const map = new Map();
-    new simpleStyle(geojson, {id: 'hello-world'}).addTo(map);
+    new simpleStyle(geojson, {id: 'hello-world'}).addTo(map).fitBounds();
 
     assert.deepEqual([ 'hello-world', 'hello-world-points' ], Object.keys(map.sources));
     assert.deepEqual(8, map.layers.length);
@@ -103,7 +103,7 @@ describe('Tests for simpleStyle()', () => {
       'features': [],
     };
 
-    new simpleStyle(empty, {id: 'hello-world'}).addTo(map);
+    new simpleStyle(empty, {id: 'hello-world'}).addTo(map).fitBounds();
 
     assert.deepEqual([ 'hello-world', 'hello-world-points' ], Object.keys(map.sources));
     assert.deepEqual(8, map.layers.length);
@@ -121,7 +121,7 @@ describe('Tests for simpleStyle()', () => {
       'features': [],
     };
 
-    const ss = new simpleStyle(empty).addTo(map); // The GeoJSON is empty.
+    const ss = new simpleStyle(empty).addTo(map).fitBounds();
 
     assert.deepEqual([ 'geolonia-simple-style', 'geolonia-simple-style-points' ], Object.keys(map.sources));
     assert.deepEqual(8, map.layers.length);


### PR DESCRIPTION
simpleStyle では、GeoJSON を読み込んだあとに `maplibre.Map.fitBounds()` を発火させて、GeoJSON の地物が自動的に表示されるように地図を移動させていたが、 #280 で実装された方法だと、 fitBounds() を発火させたくないときにも強制的に発火してしまうため、この機能をデフォルトで Off にして、別途 fitBounds() を実行させるよう変更する。

なお、従来の `<div />` で GeoJSON を指定する方法では、lat および lng が指定されていないときだけ `fitBounds()` が発火する。（この挙動は今回のプルリクでは変わっていない。）