### PR TITLE
Move async import from simplestyle to sanitizeHtml

### DIFF
--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -222,11 +222,7 @@ export default class GeoloniaMap extends maplibregl.Map {
         });
         ss.addTo(map);
 
-        // eslint-disable-next-line no-console
-        console.log('before fitBounds check', container.dataset);
         if (!container.dataset || (!container.dataset.lng && !container.dataset.lat)) {
-          // eslint-disable-next-line no-console
-          console.log('in fitBounds');
           ss.fitBounds();
         }
       }

--- a/src/lib/simplestyle-vector.js
+++ b/src/lib/simplestyle-vector.js
@@ -2,7 +2,6 @@
 
 import maplibregl from 'maplibre-gl';
 import turfCenter from '@turf/center';
-import sanitizeHtml from 'sanitize-html';
 
 const textColor = '#000000';
 const textHaloColor = '#FFFFFF';
@@ -204,7 +203,8 @@ class SimpleStyleVector {
     this.setPopup(map, 'vt-circle-simple-style-points');
   }
 
-  setPopup(map, source) {
+  async setPopup(map, source) {
+    const { default: sanitizeHtml } = await import('sanitize-html');
     map.on('click', source, (e) => {
       const center = turfCenter(e.features[0]).geometry.coordinates;
       const description = e.features[0].properties.description;

--- a/src/lib/simplestyle.js
+++ b/src/lib/simplestyle.js
@@ -3,7 +3,6 @@
 import maplibregl from 'maplibre-gl';
 import geojsonExtent from '@mapbox/geojson-extent';
 import turfCenter from '@turf/center';
-import sanitizeHtml from 'sanitize-html';
 
 const textColor = '#000000';
 const textHaloColor = '#FFFFFF';
@@ -126,7 +125,9 @@ class SimpleStyle {
 
     const bounds = geojsonExtent(this.geojson);
     if (bounds) {
-      this.map.fitBounds(bounds, _options);
+      window.requestAnimationFrame(() => {
+        this.map.fitBounds(bounds, _options);
+      });
     }
 
     return this;
@@ -232,7 +233,8 @@ class SimpleStyle {
     this.setPopup(this.map, `${this.options.id}-circle-points`);
   }
 
-  setPopup(map, source) {
+  async setPopup(map, source) {
+    const { default: sanitizeHtml } = await import('sanitize-html');
     map.on('click', source, (e) => {
       const center = turfCenter(e.features[0]).geometry.coordinates;
       const description = e.features[0].properties.description;

--- a/src/lib/simplestyle.test.js
+++ b/src/lib/simplestyle.test.js
@@ -2,6 +2,9 @@
 
 import assert from 'assert';
 
+window.URL.createObjectURL = () => {}; // To prevent `TypeError: window.URL.createObjectURL is not a function`
+window.requestAnimationFrame = (cb) => cb();
+
 class Map {
   constructor(json, options) {
     this.json = json;
@@ -69,7 +72,6 @@ const geojson = {
 
 describe('Tests for simpleStyle()', () => {
   it('should has sources and layers as expected', async () => {
-    window.URL.createObjectURL = () => {}; // To prevent `TypeError: window.URL.createObjectURL is not a function`
     const { default: simpleStyle } = await import('./simplestyle');
 
     const map = new Map();
@@ -81,7 +83,6 @@ describe('Tests for simpleStyle()', () => {
   });
 
   it('should has sources and layers as expected with custom IDs', async () => {
-    window.URL.createObjectURL = () => {}; // To prevent `TypeError: window.URL.createObjectURL is not a function`
     const { default: simpleStyle } = await import('./simplestyle');
 
     const map = new Map();
@@ -93,7 +94,6 @@ describe('Tests for simpleStyle()', () => {
   });
 
   it('should has sources and layers as expected with empty GeoJSON', async () => {
-    window.URL.createObjectURL = () => {}; // To prevent `TypeError: window.URL.createObjectURL is not a function`
     const { default: simpleStyle } = await import('./simplestyle');
 
     const map = new Map();
@@ -111,7 +111,6 @@ describe('Tests for simpleStyle()', () => {
   });
 
   it('should update GeoJSON', async () => {
-    window.URL.createObjectURL = () => {}; // To prevent `TypeError: window.URL.createObjectURL is not a function`
     const { default: simpleStyle } = await import('./simplestyle');
 
     const map = new Map();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1948,17 +1948,10 @@ camelcase@^5.0.0, camelcase@^5.2.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-caniuse-lite@^1.0.30001259:
-  version "1.0.30001260"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz#e3be3f34ddad735ca4a2736fa9e768ef34316270"
-  integrity sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==
-  dependencies:
-    nanocolors "^0.1.0"
-
-caniuse-lite@^1.0.30001265:
-  version "1.0.30001270"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001270.tgz#cc9c37a4ec5c1a8d616fc7bace902bb053b0cdea"
-  integrity sha512-TcIC7AyNWXhcOmv2KftOl1ShFAaHQYcB/EPL/hEyMrcS7ZX0/DvV1aoy6BzV0+16wTpoAyTMGDNAJfSqS/rz7A==
+caniuse-lite@^1.0.30001259, caniuse-lite@^1.0.30001265:
+  version "1.0.30001322"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz"
+  integrity sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==
 
 chalk@^1.1.3:
   version "1.1.3"
@@ -4401,7 +4394,7 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-nanocolors@^0.1.0, nanocolors@^0.1.5:
+nanocolors@^0.1.5:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/nanocolors/-/nanocolors-0.1.12.tgz#8577482c58cbd7b5bb1681db4cf48f11a87fd5f6"
   integrity sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==


### PR DESCRIPTION
sanitizeHtml がバンドルサイズに150kbぐらい追加で入っているので、非同期で読み込むように変更（popupが設定されている場合のみ）

@miya0001 `data-geojson="#css-selector"` の挙動で、setBoundsがうまく行かなかったので、なぜか下記のように修正したら動きました。。心当たりあります？

```
      window.requestAnimationFrame(() => {
        this.map.fitBounds(bounds, _options);
      });
```