### PR TITLE
Set Geojson as URL for simpleStyle class

### DIFF
--- a/docs/simplestyle.html
+++ b/docs/simplestyle.html
@@ -7,10 +7,10 @@
   <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
   <title>SimpleStyle + @geolonia/embed</title>
   <style>
-    body, #map {
+    body, .map {
       margin: 0;
       width: 100vw;
-      height: 100vh;
+      height: 50vh;
       overflow: hidden;
     }
   </style>
@@ -18,12 +18,13 @@
 
 <body>
 
-  <div id="map"></div>
+  <div id="map1" class="map"></div>
+  <div id="map2" class="map"></div>
 
   <script type="text/javascript" src="./embed?geolonia-api-key=YOUR-API-KEY"></script>
 
   <script>
-  const map = new geolonia.Map('#map')
+  const map1 = new geolonia.Map('#map1')
 
   const geojson = {
     "type": "FeatureCollection",
@@ -67,7 +68,8 @@
     "features": []
   }
 
-  map.on('load', () => {
+  const updateGeoJsonByInterval = (map, geojson) => {
+
     const ss = new geolonia.simpleStyle(geojson, {
       id: 'test'
     })
@@ -84,6 +86,22 @@
         ss.updateData(empty)
       }
     }, 2000)
+
+  }
+
+  map1.on('load', () => {
+
+    updateGeoJsonByInterval(map1, geojson);
+
+  })
+
+  const map2 = new geolonia.Map('#map2')
+  const geojsonUrl = 'https://gist.githubusercontent.com/miya0001/56c3dc174f5cdf1d9565cbca0fbd3c48/raw/c13330036d28ef547a8a87cb6df3fa12de19ddb6/test.geojson';
+
+  map2.on('load', () => {
+
+    updateGeoJsonByInterval(map2, geojsonUrl);
+
   })
   </script>
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "jsdom": "^16.2.2",
     "jsdom-global": "^3.0.2",
     "mocha": "^5.2.0",
+    "node-fetch": "2",
     "pngjs": "^6.0.0",
     "prettier-eslint": "^12.0.0",
     "prettier-eslint-cli": "^5.0.0",

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -211,6 +211,8 @@ export default class GeoloniaMap extends maplibregl.Map {
         let json;
         if (el) {
           json = JSON.parse(el.textContent);
+        } else {
+          json = atts.geojson;
         }
 
         const ss = new SimpleStyle(json, {

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -211,9 +211,6 @@ export default class GeoloniaMap extends maplibregl.Map {
         let json;
         if (el) {
           json = JSON.parse(el.textContent);
-        } else {
-          const response = await fetch(atts.geojson);
-          json = await response.json();
         }
 
         const ss = new SimpleStyle(json, {

--- a/src/lib/simplestyle.js
+++ b/src/lib/simplestyle.js
@@ -43,7 +43,7 @@ class SimpleStyle {
 
       };
 
-      fetchGeoJSON();
+      this._loadingPromise = fetchGeoJSON();
 
     } else {
       this.geojson = geojson;

--- a/src/lib/simplestyle.js
+++ b/src/lib/simplestyle.js
@@ -20,34 +20,7 @@ class SimpleStyle {
 
     this.callFitBounds = false;
 
-    if (typeof geojson === 'string' && isURL(geojson)) {
-
-      this.geojson = template;
-
-      const fetchGeoJSON = async () => {
-
-        try {
-
-          const response = await window.fetch(geojson);
-          const data = await response.json();
-          this.geojson = data;
-
-          if (this.callFitBounds) {
-            this.fitBounds();
-          }
-
-        } catch (error) {
-
-          console.error(error);
-        }
-
-      };
-
-      this._loadingPromise = fetchGeoJSON();
-
-    } else {
-      this.geojson = geojson;
-    }
+    this.setGeoJSON(geojson);
 
     this.options = {
       id: 'geolonia-simple-style',
@@ -59,7 +32,10 @@ class SimpleStyle {
   }
 
   updateData(geojson) {
-    const features = geojson.features;
+
+    this.setGeoJSON(geojson);
+
+    const features = this.geojson.features;
     const polygonandlines = features.filter((feature) => (feature.geometry.type.toLowerCase() !== 'point'));
     const points = features.filter((feature) => (feature.geometry.type.toLowerCase() === 'point'));
 
@@ -343,6 +319,39 @@ class SimpleStyle {
     this.map.on('mouseleave', `${this.options.id}-clusters`, () => {
       this.map.getCanvas().style.cursor = '';
     });
+  }
+
+  setGeoJSON(geojson) {
+
+    if (typeof geojson === 'string' && isURL(geojson)) {
+
+      this.geojson = template;
+
+      const fetchGeoJSON = async () => {
+
+        try {
+
+          const response = await window.fetch(geojson);
+          const data = await response.json();
+          this.geojson = data;
+
+          if (this.callFitBounds) {
+            this.fitBounds();
+          }
+
+        } catch (error) {
+
+          console.error(error); // eslint-disable-line no-console
+        }
+
+      };
+
+      this._loadingPromise = fetchGeoJSON();
+
+    } else {
+      this.geojson = geojson;
+    }
+
   }
 }
 

--- a/src/lib/simplestyle.js
+++ b/src/lib/simplestyle.js
@@ -49,8 +49,6 @@ class SimpleStyle {
       'features': points,
     });
 
-    this.geojson = geojson;
-
     return this;
   }
 
@@ -337,12 +335,15 @@ class SimpleStyle {
           this.updateData(data);
 
           if (this.callFitBounds) {
+
             this.fitBounds();
+            this.callFitBounds = false;
+
           }
 
         } catch (error) {
 
-          console.error(error); // eslint-disable-line no-console
+          console.error('Failed to load GeoJSON:', error); // eslint-disable-line no-console
         }
 
       };

--- a/src/lib/simplestyle.js
+++ b/src/lib/simplestyle.js
@@ -3,15 +3,51 @@
 import maplibregl from 'maplibre-gl';
 import geojsonExtent from '@mapbox/geojson-extent';
 import turfCenter from '@turf/center';
+import { isURL } from './util';
 
 const textColor = '#000000';
 const textHaloColor = '#FFFFFF';
 const backgroundColor = 'rgba(255, 0, 0, 0.4)';
 const strokeColor = '#FFFFFF';
 
+const template = {
+  'type': 'FeatureCollection',
+  'features': [],
+};
+
 class SimpleStyle {
   constructor(geojson, options) {
-    this.geojson = geojson;
+
+    this.callFitBounds = false;
+
+    if (typeof geojson === 'string' && isURL(geojson)) {
+
+      this.geojson = template;
+
+      const fetchGeoJSON = async () => {
+
+        try {
+
+          const response = await window.fetch(geojson);
+          const data = await response.json();
+          this.geojson = data;
+
+          if (this.callFitBounds) {
+            this.fitBounds();
+          }
+
+        } catch (error) {
+
+          console.error(error);
+        }
+
+      };
+
+      fetchGeoJSON();
+
+    } else {
+      this.geojson = geojson;
+    }
 
     this.options = {
       id: 'geolonia-simple-style',
@@ -117,6 +153,9 @@ class SimpleStyle {
   }
 
   fitBounds(options = {}) {
+
+    this.callFitBounds = true;
+
     const _options = {
       duration: 3000,
       padding: 30,

--- a/src/lib/simplestyle.js
+++ b/src/lib/simplestyle.js
@@ -334,6 +334,7 @@ class SimpleStyle {
           const response = await window.fetch(geojson);
           const data = await response.json();
           this.geojson = data;
+          this.updateData(data);
 
           if (this.callFitBounds) {
             this.fitBounds();

--- a/src/lib/simplestyle.test.js
+++ b/src/lib/simplestyle.test.js
@@ -1,9 +1,11 @@
 'use strict';
 
 import assert from 'assert';
+import nodeFetch from 'node-fetch';
 
 window.URL.createObjectURL = () => {}; // To prevent `TypeError: window.URL.createObjectURL is not a function`
 window.requestAnimationFrame = (cb) => cb();
+window.fetch = nodeFetch;
 
 class Map {
   constructor(json, options) {
@@ -71,64 +73,77 @@ const geojson = {
 };
 
 describe('Tests for simpleStyle()', () => {
-  it('should has sources and layers as expected', async () => {
+  // it('should has sources and layers as expected', async () => {
+  //   const { default: simpleStyle } = await import('./simplestyle');
+
+  //   const map = new Map();
+  //   new simpleStyle(geojson).addTo(map).fitBounds();
+
+  //   assert.deepEqual([ 'geolonia-simple-style', 'geolonia-simple-style-points' ], Object.keys(map.sources));
+  //   assert.deepEqual(8, map.layers.length);
+  //   assert.deepEqual(true, map.bounds);
+  // });
+
+  // it('should has sources and layers as expected with custom IDs', async () => {
+  //   const { default: simpleStyle } = await import('./simplestyle');
+
+  //   const map = new Map();
+  //   new simpleStyle(geojson, {id: 'hello-world'}).addTo(map).fitBounds();
+
+  //   assert.deepEqual([ 'hello-world', 'hello-world-points' ], Object.keys(map.sources));
+  //   assert.deepEqual(8, map.layers.length);
+  //   assert.deepEqual(true, map.bounds);
+  // });
+
+  // it('should has sources and layers as expected with empty GeoJSON', async () => {
+  //   const { default: simpleStyle } = await import('./simplestyle');
+
+  //   const map = new Map();
+
+  //   const empty = {
+  //     'type': 'FeatureCollection',
+  //     'features': [],
+  //   };
+
+  //   new simpleStyle(empty, {id: 'hello-world'}).addTo(map).fitBounds();
+
+  //   assert.deepEqual([ 'hello-world', 'hello-world-points' ], Object.keys(map.sources));
+  //   assert.deepEqual(8, map.layers.length);
+  //   assert.deepEqual(false, map.bounds);
+  // });
+
+  // it('should update GeoJSON', async () => {
+  //   const { default: simpleStyle } = await import('./simplestyle');
+
+  //   const map = new Map();
+
+  //   const empty = {
+  //     'type': 'FeatureCollection',
+  //     'features': [],
+  //   };
+
+  //   const ss = new simpleStyle(empty).addTo(map).fitBounds();
+
+  //   assert.deepEqual([ 'geolonia-simple-style', 'geolonia-simple-style-points' ], Object.keys(map.sources));
+  //   assert.deepEqual(8, map.layers.length);
+  //   assert.deepEqual(false, map.bounds);
+  //   assert.deepEqual(0, map.sources['geolonia-simple-style-points'].data.features.length);
+
+  //   ss.updateData(geojson); // The GeoJSON is not empty.
+  //   assert.deepEqual(false, map.bounds); // `fitBounds()` doesn't fire.
+  //   assert.deepEqual(1, map.sources['geolonia-simple-style-points'].data.features.length);
+  // });
+
+  it('should load GeoJSON from url', async () => {
     const { default: simpleStyle } = await import('./simplestyle');
 
     const map = new Map();
+    const geojson = 'https://gist.githubusercontent.com/miya0001/56c3dc174f5cdf1d9565cbca0fbd3c48/raw/c13330036d28ef547a8a87cb6df3fa12de19ddb6/test.geojson';
     new simpleStyle(geojson).addTo(map).fitBounds();
 
     assert.deepEqual([ 'geolonia-simple-style', 'geolonia-simple-style-points' ], Object.keys(map.sources));
-    assert.deepEqual(8, map.layers.length);
-    assert.deepEqual(true, map.bounds);
+    // assert.deepEqual(8, map.layers.length);
+    // assert.deepEqual(true, map.bounds);
   });
 
-  it('should has sources and layers as expected with custom IDs', async () => {
-    const { default: simpleStyle } = await import('./simplestyle');
-
-    const map = new Map();
-    new simpleStyle(geojson, {id: 'hello-world'}).addTo(map).fitBounds();
-
-    assert.deepEqual([ 'hello-world', 'hello-world-points' ], Object.keys(map.sources));
-    assert.deepEqual(8, map.layers.length);
-    assert.deepEqual(true, map.bounds);
-  });
-
-  it('should has sources and layers as expected with empty GeoJSON', async () => {
-    const { default: simpleStyle } = await import('./simplestyle');
-
-    const map = new Map();
-
-    const empty = {
-      'type': 'FeatureCollection',
-      'features': [],
-    };
-
-    new simpleStyle(empty, {id: 'hello-world'}).addTo(map).fitBounds();
-
-    assert.deepEqual([ 'hello-world', 'hello-world-points' ], Object.keys(map.sources));
-    assert.deepEqual(8, map.layers.length);
-    assert.deepEqual(false, map.bounds);
-  });
-
-  it('should update GeoJSON', async () => {
-    const { default: simpleStyle } = await import('./simplestyle');
-
-    const map = new Map();
-
-    const empty = {
-      'type': 'FeatureCollection',
-      'features': [],
-    };
-
-    const ss = new simpleStyle(empty).addTo(map).fitBounds();
-
-    assert.deepEqual([ 'geolonia-simple-style', 'geolonia-simple-style-points' ], Object.keys(map.sources));
-    assert.deepEqual(8, map.layers.length);
-    assert.deepEqual(false, map.bounds);
-    assert.deepEqual(0, map.sources['geolonia-simple-style-points'].data.features.length);
-
-    ss.updateData(geojson); // The GeoJSON is not empty.
-    assert.deepEqual(false, map.bounds); // `fitBounds()` doesn't fire.
-    assert.deepEqual(1, map.sources['geolonia-simple-style-points'].data.features.length);
-  });
 });

--- a/src/lib/simplestyle.test.js
+++ b/src/lib/simplestyle.test.js
@@ -73,66 +73,66 @@ const geojson = {
 };
 
 describe('Tests for simpleStyle()', () => {
-  // it('should has sources and layers as expected', async () => {
-  //   const { default: simpleStyle } = await import('./simplestyle');
+  it('should has sources and layers as expected', async () => {
+    const { default: simpleStyle } = await import('./simplestyle');
 
-  //   const map = new Map();
-  //   new simpleStyle(geojson).addTo(map).fitBounds();
+    const map = new Map();
+    new simpleStyle(geojson).addTo(map).fitBounds();
 
-  //   assert.deepEqual([ 'geolonia-simple-style', 'geolonia-simple-style-points' ], Object.keys(map.sources));
-  //   assert.deepEqual(8, map.layers.length);
-  //   assert.deepEqual(true, map.bounds);
-  // });
+    assert.deepEqual([ 'geolonia-simple-style', 'geolonia-simple-style-points' ], Object.keys(map.sources));
+    assert.deepEqual(8, map.layers.length);
+    assert.deepEqual(true, map.bounds);
+  });
 
-  // it('should has sources and layers as expected with custom IDs', async () => {
-  //   const { default: simpleStyle } = await import('./simplestyle');
+  it('should has sources and layers as expected with custom IDs', async () => {
+    const { default: simpleStyle } = await import('./simplestyle');
 
-  //   const map = new Map();
-  //   new simpleStyle(geojson, {id: 'hello-world'}).addTo(map).fitBounds();
+    const map = new Map();
+    new simpleStyle(geojson, {id: 'hello-world'}).addTo(map).fitBounds();
 
-  //   assert.deepEqual([ 'hello-world', 'hello-world-points' ], Object.keys(map.sources));
-  //   assert.deepEqual(8, map.layers.length);
-  //   assert.deepEqual(true, map.bounds);
-  // });
+    assert.deepEqual([ 'hello-world', 'hello-world-points' ], Object.keys(map.sources));
+    assert.deepEqual(8, map.layers.length);
+    assert.deepEqual(true, map.bounds);
+  });
 
-  // it('should has sources and layers as expected with empty GeoJSON', async () => {
-  //   const { default: simpleStyle } = await import('./simplestyle');
+  it('should has sources and layers as expected with empty GeoJSON', async () => {
+    const { default: simpleStyle } = await import('./simplestyle');
 
-  //   const map = new Map();
+    const map = new Map();
 
-  //   const empty = {
-  //     'type': 'FeatureCollection',
-  //     'features': [],
-  //   };
+    const empty = {
+      'type': 'FeatureCollection',
+      'features': [],
+    };
 
-  //   new simpleStyle(empty, {id: 'hello-world'}).addTo(map).fitBounds();
+    new simpleStyle(empty, {id: 'hello-world'}).addTo(map).fitBounds();
 
-  //   assert.deepEqual([ 'hello-world', 'hello-world-points' ], Object.keys(map.sources));
-  //   assert.deepEqual(8, map.layers.length);
-  //   assert.deepEqual(false, map.bounds);
-  // });
+    assert.deepEqual([ 'hello-world', 'hello-world-points' ], Object.keys(map.sources));
+    assert.deepEqual(8, map.layers.length);
+    assert.deepEqual(false, map.bounds);
+  });
 
-  // it('should update GeoJSON', async () => {
-  //   const { default: simpleStyle } = await import('./simplestyle');
+  it('should update GeoJSON', async () => {
+    const { default: simpleStyle } = await import('./simplestyle');
 
-  //   const map = new Map();
+    const map = new Map();
 
-  //   const empty = {
-  //     'type': 'FeatureCollection',
-  //     'features': [],
-  //   };
+    const empty = {
+      'type': 'FeatureCollection',
+      'features': [],
+    };
 
-  //   const ss = new simpleStyle(empty).addTo(map).fitBounds();
+    const ss = new simpleStyle(empty).addTo(map).fitBounds();
 
-  //   assert.deepEqual([ 'geolonia-simple-style', 'geolonia-simple-style-points' ], Object.keys(map.sources));
-  //   assert.deepEqual(8, map.layers.length);
-  //   assert.deepEqual(false, map.bounds);
-  //   assert.deepEqual(0, map.sources['geolonia-simple-style-points'].data.features.length);
+    assert.deepEqual([ 'geolonia-simple-style', 'geolonia-simple-style-points' ], Object.keys(map.sources));
+    assert.deepEqual(8, map.layers.length);
+    assert.deepEqual(false, map.bounds);
+    assert.deepEqual(0, map.sources['geolonia-simple-style-points'].data.features.length);
 
-  //   ss.updateData(geojson); // The GeoJSON is not empty.
-  //   assert.deepEqual(false, map.bounds); // `fitBounds()` doesn't fire.
-  //   assert.deepEqual(1, map.sources['geolonia-simple-style-points'].data.features.length);
-  // });
+    ss.updateData(geojson); // The GeoJSON is not empty.
+    assert.deepEqual(false, map.bounds); // `fitBounds()` doesn't fire.
+    assert.deepEqual(1, map.sources['geolonia-simple-style-points'].data.features.length);
+  });
 
   it('should load GeoJSON from url', async () => {
     const { default: simpleStyle } = await import('./simplestyle');
@@ -141,6 +141,46 @@ describe('Tests for simpleStyle()', () => {
     const geojson = 'https://gist.githubusercontent.com/miya0001/56c3dc174f5cdf1d9565cbca0fbd3c48/raw/c13330036d28ef547a8a87cb6df3fa12de19ddb6/test.geojson';
     const ss = new simpleStyle(geojson);
     ss.addTo(map).fitBounds();
+
+    await ss._loadingPromise;
+
+    assert.deepEqual([ 'geolonia-simple-style', 'geolonia-simple-style-points' ], Object.keys(map.sources));
+    assert.deepEqual(8, map.layers.length);
+    assert.deepEqual(true, map.bounds);
+  });
+
+  it('should load empty GeoJSON when failed to fetch GeoJSON', async () => {
+    const { default: simpleStyle } = await import('./simplestyle');
+
+    const map = new Map();
+    const geojson = 'https://example.com/404.geojson';
+    const ss = new simpleStyle(geojson);
+    ss.addTo(map).fitBounds();
+
+    await ss._loadingPromise;
+
+    assert.deepEqual([ 'geolonia-simple-style', 'geolonia-simple-style-points' ], Object.keys(map.sources));
+    assert.deepEqual(8, map.layers.length);
+    assert.deepEqual(false, map.bounds);
+  });
+
+  it('should update GeoJSON from url', async () => {
+    const { default: simpleStyle } = await import('./simplestyle');
+
+    const map = new Map();
+    const empty = {
+      'type': 'FeatureCollection',
+      'features': [],
+    };
+
+    const ss = new simpleStyle(empty);
+    ss.addTo(map).fitBounds();
+
+    await ss._loadingPromise;
+
+    const geojson = 'https://gist.githubusercontent.com/miya0001/56c3dc174f5cdf1d9565cbca0fbd3c48/raw/c13330036d28ef547a8a87cb6df3fa12de19ddb6/test.geojson';
+
+    ss.updateData(geojson);
 
     await ss._loadingPromise;
 

--- a/src/lib/simplestyle.test.js
+++ b/src/lib/simplestyle.test.js
@@ -144,8 +144,31 @@ describe('Tests for simpleStyle()', () => {
 
     await ss._loadingPromise;
 
-    assert.deepEqual([ 'geolonia-simple-style', 'geolonia-simple-style-points' ], Object.keys(map.sources));
-    assert.deepEqual(8, map.layers.length);
+    const geometry = map.sources['geolonia-simple-style'].data.features[0].geometry;
+    const coordinates = geometry.coordinates;
+    const type = geometry.type;
+
+    const expectCoordinates = [
+      [
+        139.6870422363281,
+        35.73425097869431,
+      ],
+      [
+        139.76943969726562,
+        35.73425097869431,
+      ],
+      [
+        139.73922729492188,
+        35.66399091134812,
+      ],
+      [
+        139.70352172851562,
+        35.698571062054015,
+      ],
+    ];
+
+    assert.deepEqual(expectCoordinates, coordinates);
+    assert.deepEqual('LineString', type);
     assert.deepEqual(true, map.bounds);
   });
 
@@ -184,8 +207,31 @@ describe('Tests for simpleStyle()', () => {
 
     await ss._loadingPromise;
 
-    assert.deepEqual([ 'geolonia-simple-style', 'geolonia-simple-style-points' ], Object.keys(map.sources));
-    assert.deepEqual(8, map.layers.length);
+    const geometry = map.sources['geolonia-simple-style'].data.features[0].geometry;
+    const coordinates = geometry.coordinates;
+    const type = geometry.type;
+
+    const expectCoordinates = [
+      [
+        139.6870422363281,
+        35.73425097869431,
+      ],
+      [
+        139.76943969726562,
+        35.73425097869431,
+      ],
+      [
+        139.73922729492188,
+        35.66399091134812,
+      ],
+      [
+        139.70352172851562,
+        35.698571062054015,
+      ],
+    ];
+
+    assert.deepEqual(expectCoordinates, coordinates);
+    assert.deepEqual('LineString', type);
     assert.deepEqual(true, map.bounds);
   });
 

--- a/src/lib/simplestyle.test.js
+++ b/src/lib/simplestyle.test.js
@@ -139,11 +139,14 @@ describe('Tests for simpleStyle()', () => {
 
     const map = new Map();
     const geojson = 'https://gist.githubusercontent.com/miya0001/56c3dc174f5cdf1d9565cbca0fbd3c48/raw/c13330036d28ef547a8a87cb6df3fa12de19ddb6/test.geojson';
-    new simpleStyle(geojson).addTo(map).fitBounds();
+    const ss = new simpleStyle(geojson);
+    ss.addTo(map).fitBounds();
+
+    await ss._loadingPromise;
 
     assert.deepEqual([ 'geolonia-simple-style', 'geolonia-simple-style-points' ], Object.keys(map.sources));
-    // assert.deepEqual(8, map.layers.length);
-    // assert.deepEqual(true, map.bounds);
+    assert.deepEqual(8, map.layers.length);
+    assert.deepEqual(true, map.bounds);
   });
 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4424,6 +4424,13 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-fetch@2:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-fetch@^2.6.1:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"


### PR DESCRIPTION
SimpleStyle Class に URL形式で GeoJSON をセットできる様に修正しました。

```
  const geojson = 'https://example.com/test.geojson';
  new simpleStyle(geojson);
```

```
  const emptyGeoJson = 'https://example.com/empty.geojson';
  const geojson = 'https://example.com/test.geojson';

  const ss = new simpleStyle(emptyGeoJson);
  ss.updateData(geojson);
```

テスト時のみ geojson を fetch するのに `node-fetch` を使っています。`node-fetch` の 3系が CommonJS で使えないと書いてあったので、バージョン2 を使用しています。

https://www.npmjs.com/package/node-fetch#:~:text=from%20%27node%2Dfetch%27%3B-,CommonJS,-node%2Dfetch%20from