### PR TITLE
Call map.remove() to prevent memory leak if HTML Embed API used

### DIFF
--- a/src/embed.js
+++ b/src/embed.js
@@ -33,6 +33,16 @@ if ( util.checkPermission() ) {
       map[isRemoved] = true;
     });
 
+    // remove map instance automatically if the container removed.
+    // prevent memory leak
+    const observer = new MutationObserver((mutationRecords) => {
+      const removed = mutationRecords.some((record) => [...record.removedNodes].some((node) => node === target));
+      if (removed && !map[isRemoved]) {
+        map.remove();
+      }
+    });
+    observer.observe(target.parentNode, { childList: true });
+
     // plugin
     const atts = parseAtts(target);
     if (isDOMContentLoaded && !map[isRemoved]) {


### PR DESCRIPTION
HTML Embed の場合は、`map.remove()` まで面倒を見るように変更。コンテナ要素が取り除かれた時に `map.remove()` をコールする。
