### PR TITLE
Remove geoloniaMap from container when calling remove()

### DIFF
--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -280,4 +280,10 @@ export default class GeoloniaMap extends maplibregl.Map {
     // Calls `maplibregl.Map.setStyle()`.
     super.setStyle.call(this, style, options);
   }
+
+  remove() {
+    const container = this.getContainer();
+    super.remove.call(this);
+    delete container.geoloniaMap;
+  }
 }


### PR DESCRIPTION
同じHTMLエレメントで一回地図を削除してもう一度作ろうとすると初期化しないバグを修正。

現状、こういうプロセスでバグが再現出来ます。

1. `map = new geolonia.Map('#map')`
2. map が正しく読み込まれる
3. `map.remove()`
4. map が消える
5. `map2 = new geolonia.Map('#map')`
6. 新しい地図が初期化しない

