### PR TITLE
Set font-size 12px for attribution to prevent overwrite by other css

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -119,7 +119,7 @@
 
 .maplibregl-ctrl-attrib-inner.mapboxgl-ctrl-attrib-inner {
   display: block!important;
-  font-size: 12px;
+  font-size: 12px!important;
 }
 
 .mapboxgl-ctrl-attrib.mapboxgl-compact .mapboxgl-ctrl-attrib-inner,
@@ -135,6 +135,6 @@
 }
 
 .mapboxgl-ctrl-attrib a, .maplibregl-ctrl-attrib a {
-  font-size: 12px;
+  font-size: 12px!important;
 }
 /* End: CSS for Attribution */

--- a/src/style.css
+++ b/src/style.css
@@ -119,6 +119,7 @@
 
 .maplibregl-ctrl-attrib-inner.mapboxgl-ctrl-attrib-inner {
   display: block!important;
+  font-size: 12px;
 }
 
 .mapboxgl-ctrl-attrib.mapboxgl-compact .mapboxgl-ctrl-attrib-inner,
@@ -131,5 +132,9 @@
 .maplibregl-ctrl-attrib.maplibregl-compact-show .maplibregl-ctrl-attrib-inner,
 .maplibregl-ctrl-attrib.maplibregl-compact .maplibregl-ctrl-attrib-button {
   display: block!important;
+}
+
+.mapboxgl-ctrl-attrib a, .maplibregl-ctrl-attrib a {
+  font-size: 12px;
 }
 /* End: CSS for Attribution */


### PR DESCRIPTION
[以下のサイト](https://jiyugaoka.iemeshi.jp/#/)で、Attribution が崩れていたので原因を調べてみると、

<img width="471" alt="スクリーンショット 2022-09-28 18 35 35" src="https://user-images.githubusercontent.com/8760841/192745117-bb946671-a787-482a-8e0e-8ccaa56cacaa.png">

Webサイト側で下の CSS が指定されていたのが原因でした。

```
* {
    font-size: 16px;
}
```

なので、attribution のフォントサイズ 12px を外部 CSS に上書きされないように、`font-size: 12px!important` を指定しました。

![スクリーンショット 2022-09-28 18 40 57](https://user-images.githubusercontent.com/8760841/192746457-70b4b79d-9710-4bdd-bd1a-8b14e94f8c93.png)