### PR TITLE
Set font-size 12px for attribution

### DIFF
--- a/src/lib/CustomAttributionControl.js
+++ b/src/lib/CustomAttributionControl.js
@@ -48,6 +48,7 @@ class CustomAttributionControl {
     const style = document.createElement('style');
     style.textContent = `
     .maplibregl-ctrl {
+      font: 12px/20px Helvetica Neue,Arial,Helvetica,sans-serif;
       clear: both;
       pointer-events: auto;
       transform: translate(0);
@@ -61,10 +62,6 @@ class CustomAttributionControl {
       background-color: hsla(0,0%,100%,.5);
       margin: 0;
       padding: 0 5px
-    }
-
-    .maplibregl-ctrl-attrib-inner {
-      font-size: 12px;
     }
 
     @media screen {

--- a/src/lib/CustomAttributionControl.js
+++ b/src/lib/CustomAttributionControl.js
@@ -52,13 +52,19 @@ class CustomAttributionControl {
       pointer-events: auto;
       transform: translate(0);
     }
+
     .maplibregl-ctrl-attrib-button:focus,.maplibregl-ctrl-group button:focus {
       box-shadow: 0 0 2px 2px #0096ff
     }
+
     .maplibregl-ctrl.maplibregl-ctrl-attrib {
       background-color: hsla(0,0%,100%,.5);
       margin: 0;
       padding: 0 5px
+    }
+
+    .maplibregl-ctrl-attrib-inner {
+      font-size: 12px;
     }
 
     @media screen {


### PR DESCRIPTION

イエメシ自由が丘のサイトを確認すると、shadowDOM 内での フォントサイズの指定が必要だったので追加しました。

デフォルトでのフォントサイズを指定する セレクタは、以下だったのですが、
```
.mapboxgl-map, .maplibregl-map {
    font: 12px/20px Helvetica Neue,Arial,Helvetica,sans-serif;
　...
}
```

shadowDOMの中に、class名がなく（shadowDOM にも CSS を追加していなかった）ため、


```
* {
    fontsize: 16px 
　...
}
```
に上書きされていました。

https://jiyugaoka.iemeshi.jp/#/