### PR TITLE
Fix: GeoJSON で marker-symbol を指定してもアイコンが表示されない

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -161,6 +161,7 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
             "type": "Feature",
             "properties": {
               "title": "売店",
+              "description": "ここは売店です。お好きなものを買ってください。",
               "marker-color": "#ff9300",
               "marker-size": "medium",
               "marker-symbol": "star-stroked"

--- a/docs/index.html
+++ b/docs/index.html
@@ -147,8 +147,7 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
               "title": "集合場所",
               "description": "ここが集合場所です。13時までに集合してください。",
               "marker-color": "#0096ff",
-              "marker-size": "medium",
-              "marker-symbol": ""
+              "marker-size": "medium"
             },
             "geometry": {
               "type": "Point",
@@ -164,7 +163,7 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
               "title": "売店",
               "marker-color": "#ff9300",
               "marker-size": "medium",
-              "marker-symbol": "bus"
+              "marker-symbol": "star-stroked"
             },
             "geometry": {
               "type": "Point",
@@ -179,8 +178,7 @@ setInterval(function() { myMap.rotateTo( myMap.getBearing() + 90 ) }, 5000);</pr
             "properties": {
               "title": "噴水",
               "marker-color": "#ff2600",
-              "marker-size": "large",
-              "marker-symbol": ""
+              "marker-size": "large"
             },
             "geometry": {
               "type": "Point",

--- a/src/lib/simplestyle-vector.js
+++ b/src/lib/simplestyle-vector.js
@@ -197,6 +197,7 @@ class SimpleStyleVector {
     });
 
     this.setPopup(map, 'vt-circle-simple-style-points');
+    this.setPopup(map, 'vt-geolonia-simple-style-points');
   }
 
   async setPopup(map, source) {

--- a/src/lib/simplestyle-vector.js
+++ b/src/lib/simplestyle-vector.js
@@ -152,7 +152,7 @@ class SimpleStyleVector {
       type: 'circle',
       source: this.sourceName,
       'source-layer': 'g-simplestyle-v1',
-      filter: ['==', '$type', 'Point'],
+      filter: ['all', ['==', '$type', 'Point'], ['!', ['has', 'marker-symbol']]],
       paint: {
         'circle-radius': [
           'case',
@@ -180,11 +180,7 @@ class SimpleStyleVector {
         'text-halo-width': 1,
       },
       layout: {
-        'icon-image': [
-          'case',
-          ['==', 'large', ['get', 'marker-size']], ['image', ['concat', ['get', 'marker-symbol'], '-15']],
-          ['image', ['concat', ['get', 'marker-symbol'], '-11']],
-        ],
+        'icon-image': ['get', 'marker-symbol'],
         'text-field': ['get', 'title'],
         'text-font': ['Noto Sans Regular'],
         'text-size': 12,

--- a/src/lib/simplestyle-vector.js
+++ b/src/lib/simplestyle-vector.js
@@ -152,7 +152,7 @@ class SimpleStyleVector {
       type: 'circle',
       source: this.sourceName,
       'source-layer': 'g-simplestyle-v1',
-      filter: ['all', ['==', '$type', 'Point'], ['!', ['has', 'marker-symbol']]],
+      filter: ['all', ['==', '$type', 'Point'], ['!has', 'marker-symbol']],
       paint: {
         'circle-radius': [
           'case',

--- a/src/lib/simplestyle.js
+++ b/src/lib/simplestyle.js
@@ -196,7 +196,7 @@ class SimpleStyle {
       id: `${this.options.id}-circle-points`,
       type: 'circle',
       source: `${this.options.id}-points`,
-      filter: ['all', ['!', ['has', 'point_count']], ['!', ['has', 'marker-symbol']]],
+      filter: ['all', ['!has', 'point_count'], ['!has', 'marker-symbol']],
       paint: {
         'circle-radius': [
           'case',

--- a/src/lib/simplestyle.js
+++ b/src/lib/simplestyle.js
@@ -240,6 +240,7 @@ class SimpleStyle {
     });
 
     this.setPopup(this.map, `${this.options.id}-circle-points`);
+    this.setPopup(this.map, `${this.options.id}-symbol-points`);
   }
 
   async setPopup(map, source) {

--- a/src/lib/simplestyle.js
+++ b/src/lib/simplestyle.js
@@ -196,7 +196,7 @@ class SimpleStyle {
       id: `${this.options.id}-circle-points`,
       type: 'circle',
       source: `${this.options.id}-points`,
-      filter: ['!', ['has', 'point_count']],
+      filter: ['all', ['!', ['has', 'point_count']], ['!', ['has', 'marker-symbol']]],
       paint: {
         'circle-radius': [
           'case',
@@ -223,11 +223,7 @@ class SimpleStyle {
         'text-halo-width': 1,
       },
       layout: {
-        'icon-image': [
-          'case',
-          ['==', 'large', ['get', 'marker-size']], ['image', ['concat', ['get', 'marker-symbol'], '-15']],
-          ['image', ['concat', ['get', 'marker-symbol'], '-11']],
-        ],
+        'icon-image': ['get', 'marker-symbol'],
         'text-field': ['get', 'title'],
         'text-font': ['Noto Sans Regular'],
         'text-size': 12,


### PR DESCRIPTION
Close #319 #293 

現状、geojson のプロパティで、marker-symbol を指定しても、Embed API で、-11 と -15 を追加するので、
マーカーが表示されなかったので、

marker-symbol を指定時は、以下の処理をする様に修正しました。

- circle を非表示にする
- サフィックスは無しにしてユーザーが指定したアイコンをそのまま表示