### PR TITLE
cdn.geolonia.com に PR を自動作成するアクションを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,3 +98,14 @@ jobs:
         run: npm publish --access=public --tag=next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: 'Checkout geolonia/cdn.geolonia.com'
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT_FOR_CDN_GEOLONIA_COM }}
+          repository: geolonia/cdn.geolonia.com
+      - name: 'Build Embed API'
+        run: npm run build:embed
+      - name: 'Create PR in geolonia/cdn.geolonia.com'
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.PAT_FOR_CDN_GEOLONIA_COM }}


### PR DESCRIPTION
Personal Access Token である PAT_FOR_CDN_GEOLONIA_COM は @kamataryo さんにお願いして、すでに設定してもらっています。
個人アカウントで作成したものなので、いずれ共有アカウントの PAT に差し替える必要があります。

PATはFine-grained tokens で作成。geolonia/cdn.geolonia.com に対して以下の Permissions を許可しました。

| Item | Access |
| -- | -- |
| Contents | Read and write |
| Metadata | Read-only |
| Pull requests | Read and write |


