### PR TITLE
Disable localIdeographFontFamily, default is 'sans-serif'

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -198,7 +198,7 @@ export function getOptions(container, params, atts) {
     pitch: parseFloat(atts.pitch),
     zoom: parseFloat(atts.zoom),
     hash: (atts.hash === 'on'),
-    localIdeographFontFamily: 'sans-serif',
+    localIdeographFontFamily: null,
     attributionControl: false,
   };
 

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -198,7 +198,7 @@ export function getOptions(container, params, atts) {
     pitch: parseFloat(atts.pitch),
     zoom: parseFloat(atts.zoom),
     hash: (atts.hash === 'on'),
-    localIdeographFontFamily: null,
+    localIdeographFontFamily: undefined,
     attributionControl: false,
   };
 


### PR DESCRIPTION
変更前: ローカルの sans-serif が適用
<img width="664" alt="スクリーンショット 2023-04-27 19 20 47" src="https://user-images.githubusercontent.com/6292312/234834876-757b0c73-612f-418b-a8df-ad18d2d066e9.png">


変更後: 指定した Noto Sans が適用
<img width="568" alt="スクリーンショット 2023-04-27 19 20 35" src="https://user-images.githubusercontent.com/6292312/234834865-a9a4c1b3-bbe2-4e9f-8633-0f1219685e1f.png">

