### PR TITLE
support pmtiles:// protocol

### DIFF
--- a/docs/pmtiles.html
+++ b/docs/pmtiles.html
@@ -25,7 +25,8 @@
   <script src="./embed?geolonia-api-key=YOUR-API-KEY"></script>
   <script>
     const map = new geolonia.Map('#my-map');
-    <!-- git@github.com:geolonia/sandbox-s3-pmtiles.git -->
+    // git@github.com:geolonia/sandbox-s3-pmtiles.git
+    // See the Sandbox AWS Account
     const pmtiles_url = 'https://d34j6iplycp4rd.cloudfront.net/hello.pmtiles'
 
     map.on('load', () => {
@@ -34,13 +35,27 @@
         url: `pmtiles://${pmtiles_url}`
       })
       map.addLayer({
+        id: 'pmtiles-label',
+        source: 'pmtiles',
+        'source-layer': 'hello',
+        type: 'symbol',
+        layout: {
+          'text-field': '{name}',
+          'text-size': 12,
+          'text-font': [
+            'Noto Sans CJK JP Regular'
+          ],
+          'text-offset': [0, 0.7],
+        }
+      })
+      map.addLayer({
         id: 'pmtiles-circle',
         source: 'pmtiles',
         'source-layer': 'hello',
         type: 'circle',
         paint: {
           'circle-radius': 2,
-          'circle-color': 'red',
+          'circle-color': 'black',
         },
       })
     })

--- a/docs/pmtiles.html
+++ b/docs/pmtiles.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="./style.css">
+  <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+  <title>@geolonia/embed</title>
+</head>
+
+<body>
+  <h1>@geolonia/embed</h1>
+  <p>PMTiles examples for Embed API for Geolonia.</p>
+
+  <div class="example">
+    <h2>pmtiles protocol</h2>
+    <div
+      id="my-map"
+      data-zoom="6"
+      data-lat="35.977"
+      data-lng="138.374"
+      data-marker="off"
+    ></div>
+  </div>
+  <script src="./embed?geolonia-api-key=YOUR-API-KEY"></script>
+  <script>
+    const map = new geolonia.Map('#my-map');
+    <!-- git@github.com:geolonia/sandbox-s3-pmtiles.git -->
+    const pmtiles_url = 'https://d34j6iplycp4rd.cloudfront.net/hello.pmtiles'
+
+    map.on('load', () => {
+      map.addSource('pmtiles', {
+        type: 'vector',
+        url: `pmtiles://${pmtiles_url}`
+      })
+      map.addLayer({
+        id: 'pmtiles-circle',
+        source: 'pmtiles',
+        'source-layer': 'hello',
+        type: 'circle',
+        paint: {
+          'circle-radius': 2,
+          'circle-color': 'red',
+        },
+      })
+    })
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@turf/center": "^6.0.1",
     "core-js": "^3.26.1",
     "maplibre-gl": "2.4.0",
+    "pmtiles": "^2.7.2",
     "promise-polyfill": "^8.2.3",
     "sanitize-html": "^2.8.0",
     "tinycolor2": "^1.4.1",

--- a/src/embed.js
+++ b/src/embed.js
@@ -13,6 +13,10 @@ import parseAtts from './lib/parse-atts';
 import { parseApiKey } from './lib/parse-api-key';
 import pkg from '../package.json';
 import SimpleStyle from './lib/simplestyle';
+import * as pmtiles from 'pmtiles';
+
+const protocol = new pmtiles.Protocol();
+maplibregl.addProtocol('pmtiles', protocol.tile);
 
 if ( util.checkPermission() ) {
   let isDOMContentLoaded = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3177,6 +3177,11 @@ faye-websocket@^0.11.3:
   dependencies:
     websocket-driver ">=0.5.1"
 
+fflate@^0.7.3:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.7.4.tgz#61587e5d958fdabb5a9368a302c25363f4f69f50"
+  integrity sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -4821,6 +4826,13 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pmtiles@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/pmtiles/-/pmtiles-2.7.2.tgz#2f420a1110498a834f47829930162f540a959b12"
+  integrity sha512-YRdfLlvN5z94F5/e3cnEFE0TymKx6egi0vDx6NJF83rYGNLV6Lr2PsdpWkSo3oVl4e6LVj8RvaWLfpT874QH+Q==
+  dependencies:
+    fflate "^0.7.3"
 
 postcss-modules-extract-imports@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
- Enable pmtiles:// protocol
- sample: https://deploy-preview-353--geolonia-embed.netlify.app/pmtiles

使い方:

`pmtiles://https://example.com/your.pmtiles` のようにレンジリクエストが可能な URL を `pmtiles://` プロトコルで source に追加すると xyz タイルとして読み込まれます。

<img width="1600" alt="スクリーンショット 2023-05-08 10 23 05" src="https://user-images.githubusercontent.com/6292312/236714177-d399e325-3199-4297-8ca8-c55f19fb54f7.png">


