### PR TITLE
Include geolonia control for easy maintenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
-    "@geolonia/mbgl-geolonia-control": "^1.0.0",
     "@geolonia/mbgl-gesture-handling": "^1.0.15",
     "@mapbox/geojson-extent": "^1.0.0",
     "@mapbox/point-geometry": "^0.1.0",

--- a/src/lib/controls/geolonia-control.js
+++ b/src/lib/controls/geolonia-control.js
@@ -1,0 +1,34 @@
+export class GeoloniaControl {
+  onAdd() {
+    this.container = document.createElement('div');
+    this.container.className = 'maplibregl-ctrl';
+
+    const img = document.createElement('img');
+    img.src = 'https://cdn.geolonia.com/logo/geolonia-symbol_1.png';
+    img.style.width = '16px';
+    img.style.height = '16px';
+    img.style.display = 'block';
+    img.style.cursor = 'pointer';
+    img.style.padding = '0';
+    img.style.margin = '0';
+    img.style.border = 'none';
+    img.alt = 'Geolonia';
+
+    const link = document.createElement('a');
+    link.href = 'https://geolonia.com/';
+    link.appendChild(img);
+    link.title = 'Powered by Geolonia';
+
+    this.container.appendChild(link);
+
+    return this.container;
+  }
+
+  onRemove() {
+    this.container.parentNode.removeChild(this.container);
+  }
+
+  getDefaultPosition() {
+    return 'bottom-left';
+  }
+}

--- a/src/lib/geolonia-map.js
+++ b/src/lib/geolonia-map.js
@@ -1,7 +1,7 @@
 import 'whatwg-fetch';
 import 'promise-polyfill/src/polyfill';
 import maplibregl from 'maplibre-gl';
-import GeoloniaControl from '@geolonia/mbgl-geolonia-control';
+import { GeoloniaControl } from './controls/geolonia-control';
 import CustomAttributionControl from './CustomAttributionControl';
 import GestureHandling from '@geolonia/mbgl-gesture-handling';
 import parseAtts from './parse-atts';

--- a/src/lib/providers/amazon.js
+++ b/src/lib/providers/amazon.js
@@ -1,6 +1,6 @@
 import 'whatwg-fetch';
 import { getContainer } from '../util';
-import GeoloniaControl from '@geolonia/mbgl-geolonia-control';
+import { GeoloniaControl } from '../controls/geolonia-control';
 
 const AWS_SDK_URL = 'https://sdk.amazonaws.com/js/aws-sdk-2.775.0.min.js';
 const AMPLIFY_URL = 'https://unpkg.com/@aws-amplify/core@3.7.0/dist/aws-amplify-core.min.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,11 +1017,6 @@
     eslint-plugin-react "^7.25.1"
     typescript "^4.4.2"
 
-"@geolonia/mbgl-geolonia-control@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@geolonia/mbgl-geolonia-control/-/mbgl-geolonia-control-1.0.0.tgz#ff98f3873336334ea22079a4a72b5040d136c1f4"
-  integrity sha512-vZnZEUgaCsEhPlip/uN5FZL6nOdOA+90ir0wD5BgnbEsVaEkDsz0ktiUFlwCXjvPcHYzs1wMYYN433iZ6bEktQ==
-
 "@geolonia/mbgl-gesture-handling@^1.0.15":
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/@geolonia/mbgl-gesture-handling/-/mbgl-gesture-handling-1.0.15.tgz#ac65eaf67b94fd82fb9611c76faf9f35155e522d"


### PR DESCRIPTION
@geolonia/mbgl-geolonia-control は embed でしか使われていないため、 npm として公開されている意味があまり無いのでは？と社内で議論がありました。
メンテナンスしやすくするため、 embed に同梱し、npm としては deprecated にしようと思います。