### PR TITLE
Fix duplicate workflow runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ name: build
 
 on:
   push:
-    branches: ['*']
+    branches: [master]
     tags: ['*']
   pull_request:
     branches: [master]


### PR DESCRIPTION
現在のところ、Pull Request 作成済みのフィーチャーブランチにコミットをプッシュした場合、CI が二重に起動してしまいます。1つはブランチへのプッシュにより、もう1つは Pull Request の更新によりトリガーされたものです。
本 PR により、ブランチへのプッシュによる CI の起動が、master ブランチにプッシュした際のみに限定されるようになり、二重起動が回避されるようになります。