### PR TITLE
Fix TypeScript errors ignored with `@ts-ignore`

### DIFF
--- a/src/lib/geolonia-map.ts
+++ b/src/lib/geolonia-map.ts
@@ -164,14 +164,12 @@ export default class GeoloniaMap extends maplibregl.Map {
 
     const { enabled: geolocateControlEnabled, position: geolocateControlPosition } = util.parseControlOption(atts.geolocateControl);
     if (geolocateControlEnabled) {
-      // @ts-ignore TODO: don't ignore this
-      map.addControl(new window.geolonia.GeolocateControl(), geolocateControlPosition);
+      map.addControl(new window.geolonia.GeolocateControl({}), geolocateControlPosition);
     }
 
     const { enabled: scaleControlEnabled, position: scaleControlPosition } = util.parseControlOption(atts.scaleControl);
     if (scaleControlEnabled) {
-      // @ts-ignore TODO: don't ignore this
-      map.addControl(new window.geolonia.ScaleControl(),  scaleControlPosition);
+      map.addControl(new window.geolonia.ScaleControl({}),  scaleControlPosition);
     }
 
     map.on('load', (event) => {

--- a/src/lib/geolonia-marker.ts
+++ b/src/lib/geolonia-marker.ts
@@ -2,7 +2,6 @@
 
 import maplibregl from 'maplibre-gl';
 import tinycolor from 'tinycolor2';
-// @ts-ignore TODO do not ignore this
 import markerSVG from './marker.svg';
 import * as util from './util';
 import type { MarkerOptions } from 'maplibre-gl';

--- a/src/lib/parse-api-key.test.ts
+++ b/src/lib/parse-api-key.test.ts
@@ -12,7 +12,6 @@ describe('parse api key from dom', () => {
       <script src="https://external.example.com/?geolonia-api-key=abc"></script>
     </body></html>`).window;
 
-    // @ts-ignore TODO don't ignore this
     window.geolonia = {};
 
     const params = parseApiKey(mocDocument);
@@ -25,7 +24,6 @@ describe('parse api key from dom', () => {
       <script src="https://external.example.com/?geolonia-api-key=abc"></script>
     </body></html>`).window;
 
-    // @ts-ignore TODO don't ignore this
     window.geolonia = {
       _stage: 'testStage',
       _apiKey: 'testApiKey',
@@ -41,7 +39,6 @@ describe('parse api key from dom', () => {
       <script src="https://external.example.com/?geolonia-api-key=abc"></script>
     </body></html>`).window;
 
-    // @ts-ignore TODO don't ignore this
     window.geolonia = {
       _stage: 'testStage',
     };
@@ -57,7 +54,6 @@ describe('parse api key from dom', () => {
       <script src="https://external.example.com/?geolonia-api-key=def"></script>
     </body></html>`).window;
 
-    // @ts-ignore TODO don't ignore this
     window.geolonia = {};
 
     const params = parseApiKey(mocDocument);
@@ -71,7 +67,6 @@ describe('parse api key from dom', () => {
       <script type="text/javascript" src="https://api.geolonia.com/dev/embed?geolonia-api-key=YOUR-API-KEY"></script>
     </body></html>`).window;
 
-    // @ts-ignore TODO don't ignore this
     window.geolonia = {};
 
     const params = parseApiKey(mocDocument);
@@ -85,7 +80,6 @@ describe('parse api key from dom', () => {
       <script type="text/javascript" src="https://api.geolonia.com/v1/embed?geolonia-api-key=YOUR-API-KEY"></script>
     </body></html>`).window;
 
-    // @ts-ignore TODO don't ignore this
     window.geolonia = {};
 
     const params = parseApiKey(mocDocument);
@@ -99,7 +93,6 @@ describe('parse api key from dom', () => {
       <script type="text/javascript" src="https://api.geolonia.com/v123.4/embed?geolonia-api-key=YOUR-API-KEY"></script>
     </body></html>`).window;
 
-    // @ts-ignore TODO don't ignore this
     window.geolonia = {};
 
     const params = parseApiKey(mocDocument);

--- a/src/lib/parse-api-key.ts
+++ b/src/lib/parse-api-key.ts
@@ -2,7 +2,6 @@ import urlParse from 'url-parse';
 import { Geolonia } from '../types';
 
 function getParsedApiKey() {
-  // @ts-ignore TODO don't ignore this
   const geolonia: Geolonia = window.geolonia || {};
   if (geolonia._apiKey && geolonia._stage) {
     return {
@@ -15,7 +14,6 @@ function getParsedApiKey() {
 
 function initApiKey(document) {
   if (typeof window.geolonia === 'undefined') {
-    // @ts-ignore TODO don't ignore this
     window.geolonia = {};
   }
 

--- a/src/lib/parse-atts.test.ts
+++ b/src/lib/parse-atts.test.ts
@@ -8,8 +8,7 @@ describe('tests for parse Attributes', () => {
 
   beforeEach(() => {
     global.window = {
-      // @ts-ignore TODO do not ignore this
-      geolonia: { config: {} },
+      geolonia: {},
       // @ts-ignore TODO do not ignore this
       navigator: { languages: ['ja'] },
     };

--- a/src/lib/parse-atts.test.ts
+++ b/src/lib/parse-atts.test.ts
@@ -9,7 +9,7 @@ describe('tests for parse Attributes', () => {
   beforeEach(() => {
     global.window = {
       geolonia: {},
-      // @ts-ignore TODO do not ignore this
+      // @ts-ignore forcefully assigning values to readonly properties
       navigator: { languages: ['ja'] },
     };
   });

--- a/src/lib/util.test.ts
+++ b/src/lib/util.test.ts
@@ -106,7 +106,7 @@ describe('Tests for util.js', () => {
   describe('language detection', () => {
     it('should work with Chrome', () => {
       global.window = {
-        // @ts-ignore TODO: do not ignore this
+        // @ts-ignore forcefully assigning values to readonly properties
         navigator: {
           language: 'ja',
           languages: ['ja', 'en', 'en-US', 'ar'],
@@ -117,7 +117,7 @@ describe('Tests for util.js', () => {
 
     it('should work with iOS safari', () => {
       global.window = {
-        // @ts-ignore TODO: do not ignore this
+        // @ts-ignore forcefully assigning values to readonly properties
         navigator: {
           language: 'ja-JP',
           languages: ['ja-JP'],

--- a/src/lib/util.test.ts
+++ b/src/lib/util.test.ts
@@ -7,8 +7,10 @@ import * as util from './util';
 const base = 'https://base.example.com/parent/';
 
 before(() => {
-  // @ts-ignore TODO do not ignore this
-  global.location = { href: base };
+  global.location = {
+    ...global.location,
+    href: base,
+  };
 });
 
 describe('Tests for util.js', () => {
@@ -90,21 +92,15 @@ describe('Tests for util.js', () => {
     global.window = dom.window;
     global.document = dom.window.document;
 
-    // @ts-ignore TODO: do not ignore this
-    const options1 = util.handleMarkerOptions(document.getElementById('test-element'), { foo: 'bar' });
+    const options1 = util.handleMarkerOptions(document.getElementById('test-element'), { color: '#FF1122' });
     assert.deepEqual(document.getElementById('test-element'), options1.element);
-    // @ts-ignore TODO: do not ignore this
-    assert.deepEqual('bar', options1.foo);
+    assert.deepEqual(options1.color, '#FF1122');
 
-    // @ts-ignore TODO: do not ignore this
-    const options2 = util.handleMarkerOptions(false, { foo: 'bar' });
-    // @ts-ignore TODO: do not ignore this
-    assert.deepEqual('bar', options2.foo);
+    const options2 = util.handleMarkerOptions(false, { color: '#FF1122' });
+    assert.deepEqual(options2.color, '#FF1122');
 
-    // @ts-ignore TODO: do not ignore this
-    const options3 = util.handleMarkerOptions({ hello: 'world' }, { foo: 'bar' });
-    // @ts-ignore TODO: do not ignore this
-    assert.deepEqual('world', options3.hello);
+    const options3 = util.handleMarkerOptions({ scale: 2 }, { color: '#FF1122' });
+    assert.deepEqual(options3.scale, 2);
   });
 
   describe('language detection', () => {

--- a/src/types-internal.ts
+++ b/src/types-internal.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,7 @@ export type Geolonia = {
   SimpleStyle?: typeof SimpleStyle;
   simpleStyle?: typeof SimpleStyle; // backward compatibility
   registerPlugin?: (embedPlugin: EmbedPlugin) => void;
-} & typeof maplibregl;
+} & Partial<typeof maplibregl>;
 
 declare global {
   interface Window {


### PR DESCRIPTION
`@ts-ignore` で無視していた TypeScript エラーを修正します。