### PR TITLE
Add output.publicPath = ''

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
     filename: 'embed.js',
     chunkFilename: path.join('embed-chunks', '[chunkhash].js'),
     clean: true,
+    publicPath: '',
   },
   plugins: process.env.ANALYZE === 'true' ? [new BundleAnalyzerPlugin()] : [],
   module: {


### PR DESCRIPTION
embedをnpmとしてインポートして、jsdomでテストをかけようとしたら `Automatic publicPath is not supported in this browser` というエラーが発生しましたが、この設定をしたら行けました。

ただ、embed API の配信のときに影響がないか、まだ確認していないのでお手すきのときにできれば確認をお願いしたいです :bow:

https://stackoverflow.com/questions/64294706/webpack5-automatic-publicpath-is-not-supported-in-this-browser/64715069#64715069