### PR TITLE
Set publicPath to auto because we don't know where chunks should be l…

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     filename: 'embed.js',
     chunkFilename: path.join('embed-chunks', '[chunkhash].js'),
     clean: true,
-    publicPath: '',
+    publicPath: 'auto',
   },
   plugins: process.env.ANALYZE === 'true' ? [new BundleAnalyzerPlugin()] : [],
   module: {


### PR DESCRIPTION
…oaded from until deployment is finished

See https://webpack.js.org/guides/public-path/#automatic-publicpath