### PR TITLE
Fix TypeScript exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/embed",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Geolonia embed JS API",
   "main": "dist/embed.js",
   "types": "dist/embed.d.ts",

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -51,12 +51,12 @@ export type EmbedPlugin<PluginAttributes extends { [otherKey: string]: string } 
 // Type for `window.geolonia`
 export type Geolonia = Partial<typeof maplibregl> & {
   accessToken?: string;
-  embedVersion?: string;
-  Map?: typeof GeoloniaMap;
-  Marker?: typeof GeoloniaMarker;
-  SimpleStyle?: typeof SimpleStyle;
-  simpleStyle?: typeof SimpleStyle; // backward compatibility
-  registerPlugin?: (embedPlugin: EmbedPlugin) => void;
+  embedVersion: string;
+  Map: typeof GeoloniaMap;
+  Marker: typeof GeoloniaMarker;
+  SimpleStyle: typeof SimpleStyle;
+  simpleStyle: typeof SimpleStyle; // backward compatibility
+  registerPlugin: (embedPlugin: EmbedPlugin) => void;
 };
 
 declare global {

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -82,4 +82,10 @@ window.geolonia =
 
 renderGeoloniaMap();
 
-export { geolonia };
+export {
+  geolonia,
+  GeoloniaMap as Map,
+  GeoloniaMarker as Marker,
+  SimpleStyle,
+  embedVersion,
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,9 @@ module.exports = {
     chunkFilename: path.join('embed-chunks', '[chunkhash].js'),
     clean: true,
     publicPath: 'auto',
+    library: {
+      type: 'commonjs',
+    },
   },
   plugins: process.env.ANALYZE === 'true' ? [new BundleAnalyzerPlugin()] : [],
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,8 @@ module.exports = {
     clean: true,
     publicPath: 'auto',
     library: {
-      type: 'commonjs',
+      name: 'geoloniaEmbed',
+      type: 'umd',
     },
   },
   plugins: process.env.ANALYZE === 'true' ? [new BundleAnalyzerPlugin()] : [],


### PR DESCRIPTION
`export` の仕方を少し調整しました。

- `geolonia.*` のオブジェクトを直接 `export` する
    - `import type { geolonia } from "@geolonia/embed"` のように `type` をつけて `import` すると、 `geolonia.Map` のように型をつけることができなくなってしまうため
- CommonJS としてビルドする
    - そうしないと正常に export がされないため
- `window.geolonia.*` のオブジェクトを基本的に optional ではなくする
    - 使用時に都度 `window.geolonia.*` の各オブジェクトの Null check を行わなければならないのが手間なため