### PR TITLE
Allow `style` option for `GeoloniaMapOptions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/embed",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Geolonia embed JS API",
   "main": "dist/embed.js",
   "types": "dist/embed.d.ts",

--- a/src/lib/geolonia-map.ts
+++ b/src/lib/geolonia-map.ts
@@ -12,7 +12,7 @@ import { getContainer, getOptions, getSessionId, getStyle, handleRestrictedMode,
 
 import type { MapOptions, PointLike, StyleOptions, StyleSpecification, StyleSwapOptions } from 'maplibre-gl';
 
-export type GeoloniaMapOptions = Omit<MapOptions, 'style'> & { interactive?: boolean };
+export type GeoloniaMapOptions = MapOptions & { interactive?: boolean };
 
 type Container = HTMLElement & {
   geoloniaMap: GeoloniaMap;


### PR DESCRIPTION
JS を用いている場合、`window.geolonia.Map` コンストラクターの引数には、下記のように `style` を指定することが可能ですが、TS の場合、型エラーが発生します。
TS でも `style` を指定することができるように修正を行います。

```js
const map = new window.geolonia.Map({
  container: mapContainer.current,
  style: 'geolonia/gsi',
  hash: true,
});
```