### PR TITLE
印刷時にアトリビューションが表示されるように CSS の修正などをした

### DIFF
--- a/src/lib/CustomAttributionControl.ts
+++ b/src/lib/CustomAttributionControl.ts
@@ -35,6 +35,8 @@ class CustomAttributionControl implements IControl {
   private _attribHTML;
   private styleId;
   private styleOwner;
+  private printQuery;
+  private onMediaPrintChange;
 
   constructor(options = {}) {
     this.options = options;
@@ -224,6 +226,16 @@ class CustomAttributionControl implements IControl {
     shadow.appendChild(style);
     shadow.appendChild(this._shadowContainer);
 
+    this.printQuery = window.matchMedia('print');
+    this.onMediaPrintChange = (e) => {
+      if (e.matches) {
+        // force open
+        this._shadowContainer.setAttribute('open', '');
+        this._shadowContainer.classList.remove('maplibregl-compact-show');
+      }
+    };
+    this.printQuery.addEventListener('change', this.onMediaPrintChange);
+
     return this._container;
   }
 
@@ -239,6 +251,8 @@ class CustomAttributionControl implements IControl {
     this._map = undefined;
     this._compact = undefined;
     this._attribHTML = undefined;
+
+    this.printQuery.removeEventListener('change', this.onMediaPrintChange);
   }
 
   _setElementTitle(element, title) {

--- a/src/lib/CustomAttributionControl.ts
+++ b/src/lib/CustomAttributionControl.ts
@@ -190,6 +190,12 @@ class CustomAttributionControl implements IControl {
         }
     }
 
+    @media print {
+      .maplibregl-ctrl-attrib-button {
+        display: none!important;
+      }
+    }
+
     .maplibregl-ctrl-attrib a {
         color: rgba(0,0,0,.75);
         text-decoration: none;

--- a/src/style.css
+++ b/src/style.css
@@ -129,3 +129,9 @@
   display: block!important;
 }
 /* End: CSS for Attribution */
+
+@media print {
+  .maplibregl-control-container button {
+    display: none;
+  }
+}


### PR DESCRIPTION
- 印刷時は不要なボタン類を非表示にする
- i アイコンでトグルされている時にアトリビューションが印刷されないのに対応。印刷のメディアに切り替わったときに、トグルを強制的に開く

|`@media screen`|`@media print`|
|---|---|
|<img width="500" alt="スクリーンショット 2023-10-11 18 19 43" src="https://github.com/geolonia/embed/assets/6292312/67ab00b7-37bc-4abd-be75-0682d8f84598">|<img width="500" alt="スクリーンショット 2023-10-11 18 19 51" src="https://github.com/geolonia/embed/assets/6292312/7290a38f-d2dd-4543-af77-aa255f44031d">|

close #384
