### PR TITLE
クラスタリングクリック時のズームが効かなくなっていたので修正

### DIFF
--- a/src/lib/simplestyle.ts
+++ b/src/lib/simplestyle.ts
@@ -304,17 +304,14 @@ export class SimpleStyle {
       },
     });
 
-    this.map.on('click', `${this.options.id}-clusters`, (e) => {
+    this.map.on('click', `${this.options.id}-clusters`, async (e) => {
       const features = this.map.queryRenderedFeatures(e.point, { layers: [`${this.options.id}-clusters`] });
       const clusterId = features[0].properties.cluster_id;
-      this.map.getSource(`${this.options.id}-points`).getClusterExpansionZoom(clusterId, (err, zoom) => {
-        if (err)
-          return;
+      const zoom = await this.map.getSource(`${this.options.id}-points`).getClusterExpansionZoom(clusterId);
 
-        this.map.easeTo({
-          center: features[0].geometry.coordinates,
-          zoom: zoom,
-        });
+      this.map.easeTo({
+        center: features[0].geometry.coordinates,
+        zoom: zoom,
       });
     });
 


### PR DESCRIPTION
`getClusterExpansionZoom` が、`callback` から、promise を使うような変更があり、クラスタリングクリック時のズームが効かなくなっていたので修正しました。

> ⚠️ Changed the GeoJSONSource's getClusterExpansionZoom, getClusterChildren, getClusterLeaves methods to return a Promise instead of a callback usage ([#3421](https://github.com/maplibre/maplibre-gl-js/pull/3421))

Related to https://github.com/maplibre/maplibre-gl-js/pull/3421