### PR TITLE
Remove unused tileserver stage

### DIFF
--- a/src/lib/geolonia-map.ts
+++ b/src/lib/geolonia-map.ts
@@ -114,7 +114,7 @@ export default class GeoloniaMap extends maplibregl.Map {
 
       if (resourceType === 'Source' && transformedUrl.startsWith('https://tileserver.geolonia.com')) {
         if (atts.stage === 'dev') {
-          transformedUrlObj.hostname = `tileserver-${atts.stage}.geolonia.com`;
+          transformedUrlObj.hostname = 'tileserver-dev.geolonia.com';
         }
         transformedUrlObj.searchParams.set('sessionId', sessionId);
         transformedUrlObj.searchParams.set('key', atts.key);


### PR DESCRIPTION
Fixes #426

## Summary
- stageがdevのときのみ、tileserverのエンドポイントを変更するように変更

## Other
現在は `tileserver.geolonia.com` か `tileserver-dev.geolonia.com` しかないため、`stage`によるエンドポイントの変更は不要。
Refs #229