### PR TITLE
デフォルトスタイルを Basic v2 に変更

### DIFF
--- a/src/lib/parse-atts.test.ts
+++ b/src/lib/parse-atts.test.ts
@@ -44,7 +44,7 @@ describe('tests for parse Attributes', () => {
       simpleVector: '',
       cluster: 'on',
       clusterColor: '#ff0000',
-      style: 'geolonia/basic-v1',
+      style: 'geolonia/basic-v2',
       lang: 'ja',
       plugin: 'off',
       key: 'YOUR-API-KEY',

--- a/src/lib/parse-atts.ts
+++ b/src/lib/parse-atts.ts
@@ -48,7 +48,7 @@ export default (container, params: ParseAttsParams = {}): EmbedAttributes => {
     simpleVector: '',
     cluster: 'on',
     clusterColor: '#ff0000',
-    style: 'geolonia/basic-v1',
+    style: 'geolonia/basic-v2',
     lang: lang,
     plugin: 'off',
     key: keyring.apiKey,


### PR DESCRIPTION
## Summary

* デフォルトスタイルを basic-v1 から OSMの自動更新に対応した basic-v2 に変更しました。

以下のPRをマージ後に、マージします。
* https://github.com/geolonia/cdn.geolonia.com/pull/106
* https://github.com/geolonia/embed/pull/450


## Checklist (optional)

- [ ] Tests added/updated
- [ ] Docs updated
