### PR TITLE
Add e2e test job to CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,29 @@ jobs:
             dist/
             docs/
 
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+      - run: npm ci
+      - name: Install Playwright
+        run: npx playwright install --with-deps chromium
+      - name: Run e2e tests
+        run: npm run e2e
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   gh-pages:
     name: 'Host with GitHub Pages'
     runs-on: ubuntu-latest
@@ -87,6 +110,7 @@ jobs:
       contents: read
     needs:
       - build
+      - e2e
       - act-test
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
@@ -113,7 +137,7 @@ jobs:
         run: npm publish --access=public --tag=next
 
   deploy:
-    needs: build
+    needs: [build, e2e]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
 

--- a/e2e/basic.spec.ts
+++ b/e2e/basic.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { Geolonia } from '../src/embed';
-import { TEST_URL, waitForMapLoad } from './helper';
+import { TEST_URL, waitForMapLoad, waitForStyleLoad } from './helper';
 
 declare global {
   interface Window {
@@ -57,6 +57,7 @@ test.describe('1. 基本的な地図表示', () => {
   test('1.4 アトリビューションが表示されていること', async ({ page }) => {
     await page.goto(`${TEST_URL}/basic.html`);
     await waitForMapLoad(page);
+    await waitForStyleLoad(page);
 
     // CustomAttributionControl は Shadow DOM 内にアトリビューションを描画する
     const attributionText = await page.evaluate(() => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
## Summary
- CI に e2e テストジョブを追加（maps-core の CI パターンに準拠）
- `build` → `e2e` → `publish`/`deploy` のジョブ依存関係を設定
- Playwright reporter を CI 互換性のため `html` → `list` に変更（HTML reporter は CI 上で対話モードに入り `npm run e2e` が終了しないため）
- 1.4 アトリビューションテストに `waitForStyleLoad` を追加（attribution は TileJSON 取得後に埋まるので、canvas 出現待ちだけでは間に合わないため）

## Changes
master との累積 diff: **3 ファイル / +28 / −3 行**。コミットはファイル境界に揃えて 3 本に整理。

| 順 | ファイル | コミット | 内容 |
|---|---|---|---|
| 1 | `.github/workflows/build.yml` | `ecf8d06` | `e2e` ジョブ追加 + `publish`/`deploy` の依存関係更新 |
| 2 | `playwright.config.ts` | `c7d6223` | reporter を `html` → `list` |
| 3 | `e2e/basic.spec.ts` | `865d171` | 1.4 アトリビューションテストに `waitForStyleLoad` を追加 |

## Details
- CI では chromium のみ実行（`npm run e2e`）で実行時間を抑制
- `timeout-minutes: 30` でジョブのハング防止
- 失敗・キャンセル時も Playwright レポートをアーティファクトとしてアップロード（`if: !cancelled()`）

## Test plan
- [x] ローカルで `npm run e2e` が全 10 テスト通過を確認
- [x] CI 上で `e2e` ジョブが正常に実行されることを確認（[run #26066413337](https://github.com/geolonia/embed/actions/runs/26066413337): build 59s + e2e 54s, ともに pass）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * エンドツーエンドテストの自動実行パイプラインを追加
  * ブラウザレンダリング互換性テストを改善
  * スタイル読み込み待機を組み込み、表示検証の安定性を向上しフレークを低減

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geolonia/embed/pull/480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->