### PR TITLE
test(e2e): backport maps-core PR #81 — robust minimal style fixture

### DIFF
--- a/docs/e2e/sample-basic-style.json
+++ b/docs/e2e/sample-basic-style.json
@@ -1,0 +1,24 @@
+{
+  "version": 8,
+  "glyphs": "/glyphs/{fontstack}/{range}.pbf",
+  "sources": {
+    "fixture": {
+      "type": "geojson",
+      "data": { "type": "FeatureCollection", "features": [] },
+      "attribution": "<a href=\"https://example.com\">Test fixture</a>"
+    }
+  },
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": { "background-color": "#cccccc" }
+    },
+    {
+      "id": "fixture",
+      "type": "fill",
+      "source": "fixture",
+      "paint": { "fill-color": "#cccccc" }
+    }
+  ]
+}

--- a/e2e/helper.ts
+++ b/e2e/helper.ts
@@ -98,7 +98,12 @@ const GEOLONIA_TILE_PBF_REGEX = new RegExp(
  * Geolonia のスタイル/タイル/スプライト等を最小レスポンスでモックする。
  * テスト先頭の beforeEach で呼ぶ前提。
  *
- * 返すスタイルは layers=[background] のみのミニマル style v8。
+ * 返すスタイルは maps-core の sample-basic-style.json (PR #81) に揃えた
+ * minimal style v8。具体的には:
+ * - `glyphs` フィールド (symbol layer が silently skip されないため必須)
+ * - dummy `fixture` source + attribution (attribution テストで集計対象を作る)
+ * - background + fixture fill レイヤ
+ *
  * 認証URL検証など transformRequest の挙動は実リクエスト前にここで握る。
  */
 export async function mockGeoloniaTiles(page: Page) {
@@ -109,15 +114,24 @@ export async function mockGeoloniaTiles(page: Page) {
       contentType: 'application/json',
       body: JSON.stringify({
         version: 8,
-        sources: {},
+        glyphs: '/glyphs/{fontstack}/{range}.pbf',
+        sources: {
+          fixture: {
+            type: 'geojson',
+            data: { type: 'FeatureCollection', features: [] },
+            attribution: '<a href="https://example.com">Test fixture</a>',
+          },
+        },
         layers: [
           { id: 'background', type: 'background', paint: { 'background-color': '#cccccc' } },
+          { id: 'fixture', type: 'fill', source: 'fixture', paint: { 'fill-color': '#cccccc' } },
         ],
       }),
     }),
   );
 
-  // スプライト / グリフ / フォント関連は 404 でよい (background のみなので参照されない)
+  // スプライト / グリフ / フォント関連は 404 でよい (実体は不要だが minimal style 内の
+  // glyphs path に対するリクエストが net error にならないよう route で握る)
   await page.route(/cdn\.geolonia\.com\/(sprite|glyph|font)/, (route) =>
     route.fulfill({ status: 404, body: '' }),
   );

--- a/e2e/sample.spec.ts
+++ b/e2e/sample.spec.ts
@@ -20,7 +20,9 @@ test.describe('PR0 helper sanity', () => {
 
     expect(await hasMapInstance(page)).toBe(true);
     const layers = await getStyleLayerIds(page);
-    expect(layers).toEqual(['background']);
+    // mockGeoloniaTiles の minimal style に含まれるレイヤ
+    // (background + fixture。fixture は attribution 検証用の dummy source)
+    expect(layers).toEqual(['background', 'fixture']);
   });
 
   test('recordRequests で geolonia 系へのリクエストを観測できる', async ({ page }) => {


### PR DESCRIPTION
Closes #490
Part of #411

## Summary

maps-core PR https://github.com/geolonia/maps-core/pull/81 で適用された E2E flaky 対策と同じ解決策を embed の helper に backport。

embed の E2E は現状 4 spec / 10 ケースで外部依存は `external-style.spec.ts` (smoke) のみだが、`mockGeoloniaTiles` が返す minimal style が以下の点で robust ではなかった:

- `glyphs` フィールド未設定 → MapLibre が symbol layer の add を silently skip する条件
- `attribution` を持つ source が無い → attribution 取得テストで集計対象が空

将来の Phase 1a 以降 (data 属性、marker/popup、コントロール、SimpleStyle 等) で symbol layer や attribution を使うテストが追加されたときに flaky 化する**前に**予防的に修正する。

## 変更内容

### `e2e/helper.ts`

`mockGeoloniaTiles` が返す minimal style を maps-core の `sample-basic-style.json` と同等構造に:

```json
{
  "version": 8,
  "glyphs": "/glyphs/{fontstack}/{range}.pbf",
  "sources": {
    "fixture": {
      "type": "geojson",
      "data": { "type": "FeatureCollection", "features": [] },
      "attribution": "<a href=\"https://example.com\">Test fixture</a>"
    }
  },
  "layers": [
    { "id": "background", "type": "background", "paint": { "background-color": "#cccccc" } },
    { "id": "fixture", "type": "fill", "source": "fixture", "paint": { "fill-color": "#cccccc" } }
  ]
}
```

### `e2e/sample.spec.ts`

`getStyleLayerIds` の期待値を `['background', 'fixture']` に更新。

### `docs/e2e/sample-basic-style.json` (新規)

同一の fixture を JSON ファイルとしても配置。後続フェーズで HTML テストページから `data-style="./sample-basic-style.json"` で参照可能。

## 維持する外部依存

maps-core PR #81 と同じ方針で、`external-style.spec.ts` は外部 URL (`tile.openstreetmap.jp`) のままにする。外部 fetch 検証が目的のため。

## Test plan

- [x] `npm run e2e -- --reporter=list` で 10/10 グリーン
- [x] `external-style.spec.ts` も pass (外部 URL のまま動作)
- [ ] レビュアによる minimal style 構造の妥当性確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * サンプルのMapbox v8スタイルJSONが追加され、より詳細なスタイル設定とアトリビューション検証に対応しました。

* **テスト**
  * サニティチェックテストの期待スタイルレイヤを更新し、追加レイヤおよびアトリビューション用fixtureへの対応を確認する内容に改善しました。

* **ドキュメント**
  * スタイルJSONおよびテスト内の用途や注意点に関するコメントを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->