### PR TITLE
test(e2e): legacy コンストラクタ規約を maps-core 0.4.2 (#90) で検証

### DIFF
--- a/docs/e2e/legacy-constructor.html
+++ b/docs/e2e/legacy-constructor.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="../style.css">
+  <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+  <title>@geolonia/embed - legacy constructor (maps-core#90)</title>
+  <style>
+    .m { width: 400px; height: 300px; }
+  </style>
+</head>
+<body>
+  <!--
+    maps-core#90 の後方互換な呼び出し規約 (セレクタ文字列 / HTMLElement /
+    options オブジェクト) を embed バンドルの window.geolonia.Map 経由で検証する。
+    コンテナは意図的に `.geolonia` クラスを付けない: embed の auto-scan
+    (renderGeoloniaMap) が触らないようにして、spec 側でプログラム的に構築する。
+  -->
+  <div id="map-selector" class="m" data-lat="35" data-lng="139" data-zoom="10"></div>
+  <div id="map-element" class="m" data-lat="34" data-lng="135" data-zoom="8"></div>
+  <div id="map-options" class="m" data-zoom="2"></div>
+  <script src="../embed?geolonia-api-key=YOUR-API-KEY"></script>
+</body>
+</html>

--- a/e2e/legacy-constructor.spec.ts
+++ b/e2e/legacy-constructor.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import { Geolonia } from '../src/embed';
+import {
+  TEST_URL,
+  mockGeoloniaTiles,
+  waitForStyleLoad,
+  getCenter,
+  getZoom,
+  hasMapInstance,
+} from './helper';
+
+declare global {
+  interface Window {
+    geolonia: Geolonia;
+  }
+}
+
+/**
+ * maps-core#90 を embed 経由で検証する。embed は `window.geolonia.Map` に
+ * maps-core の GeoloniaMap をそのまま公開しているため、旧 embed 由来の呼び出し
+ * 規約 —— CSS セレクタ文字列 / HTMLElement / options オブジェクト —— が
+ * wrapper 越しに壊れていないことをここで守る。
+ *
+ * legacy 形式 (文字列 / 要素) のときにコンテナの data-* を読むのは maps-core#90 の
+ * legacy パスの責務で、embed 側の parse-atts (auto-scan 経路) とは別。よって
+ * コンテナには `.geolonia` を付けず、auto-render と混ざらない状態で構築する。
+ */
+test.describe('legacy コンストラクタ引数 (maps-core#90, wrapper 経由)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockGeoloniaTiles(page);
+    await page.goto(`${TEST_URL}/legacy-constructor.html`);
+    // embed バンドルのロード (window.geolonia.Map の公開) を待つ。
+    await page.waitForFunction(
+      () => typeof window.geolonia?.Map === 'function',
+    );
+  });
+
+  test('CSS セレクタ文字列で構築し、その要素の data-* を反映する', async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const map = new window.geolonia.Map('#map-selector');
+      return map.getContainer().id;
+    });
+    await waitForStyleLoad(page, '#map-selector');
+
+    expect(await hasMapInstance(page, '#map-selector')).toBe(true);
+    const center = await getCenter(page, '#map-selector');
+    expect(center.lat).toBeCloseTo(35, 4);
+    expect(center.lng).toBeCloseTo(139, 4);
+    expect(await getZoom(page, '#map-selector')).toBeCloseTo(10, 4);
+  });
+
+  test('HTMLElement で構築し、その要素の data-* を反映する', async ({ page }) => {
+    await page.evaluate(() => {
+      const el = document.getElementById('map-element');
+      if (!el) throw new Error('fixture #map-element missing');
+      const map = new window.geolonia.Map(el);
+      return map.getContainer().id;
+    });
+    await waitForStyleLoad(page, '#map-element');
+
+    const center = await getCenter(page, '#map-element');
+    expect(center.lat).toBeCloseTo(34, 4);
+    expect(center.lng).toBeCloseTo(135, 4);
+    expect(await getZoom(page, '#map-element')).toBeCloseTo(8, 4);
+  });
+
+  test('options オブジェクトは data-* を読まず、options が優先される', async ({
+    page,
+  }) => {
+    // #map-options には decoy の data-zoom="2" があるが、object 形式では読まれず
+    // options.center / zoom が使われる (maps-core#90 の「object 素通し」契約)。
+    await page.evaluate(() => {
+      const map = new window.geolonia.Map({
+        container: '#map-options',
+        center: [140, 36],
+        zoom: 7,
+      });
+      return map.getContainer().id;
+    });
+    await waitForStyleLoad(page, '#map-options');
+
+    const center = await getCenter(page, '#map-options');
+    expect(center.lat).toBeCloseTo(36, 4);
+    expect(center.lng).toBeCloseTo(140, 4);
+    // data-zoom="2" ではなく options.zoom=7 が効く。
+    expect(await getZoom(page, '#map-options')).toBeCloseTo(7, 4);
+  });
+
+  test('存在しないセレクタは Geolonia のエラーを投げる', async ({ page }) => {
+    const message = await page.evaluate(() => {
+      try {
+        const map = new window.geolonia.Map('#no-such-container');
+        return map.getContainer().id;
+      } catch (e) {
+        return (e as Error).message;
+      }
+    });
+    expect(message).toMatch(/No HTML elements found/);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@geolonia/embed",
-  "version": "5.2.2",
+  "version": "6.0.0-pre.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/embed",
-      "version": "5.2.2",
+      "version": "6.0.0-pre.1",
       "license": "MIT",
       "dependencies": {
-        "@geolonia/maps-core": "^0.4.1",
+        "@geolonia/maps-core": "^0.4.2",
         "@playwright/test": "^1.61.1",
         "maplibre-gl": "5.19.0"
       },
@@ -503,9 +503,9 @@
       }
     },
     "node_modules/@geolonia/maps-core": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@geolonia/maps-core/-/maps-core-0.4.1.tgz",
-      "integrity": "sha512-GA8bdwoNERwKQgpbV8khO2LQNwcIdUGi9n8PCpQ9R9Wk2ZJmvF0hOA1WQslj1OCB6c/Cz4/3HiPUQPsb8gT6RA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@geolonia/maps-core/-/maps-core-0.4.2.tgz",
+      "integrity": "sha512-xH5pobfedxl4tTgiAqwT63x6c/TEi5dKKgIUV8MQGZDr70n+9UpYtfjowGAig6VkOM96m55a7YaVexGvL2XKkw==",
       "license": "MIT",
       "dependencies": {
         "@geolonia/maplibre-gesture-handling": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/embed",
-  "version": "6.0.0-pre.0",
+  "version": "6.0.0-pre.1",
   "description": "Geolonia embed JS API",
   "main": "dist/embed.js",
   "types": "dist/src/embed.d.ts",
@@ -66,7 +66,7 @@
     "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
-    "@geolonia/maps-core": "^0.4.1",
+    "@geolonia/maps-core": "^0.4.2",
     "@playwright/test": "^1.61.1",
     "maplibre-gl": "5.19.0"
   }


### PR DESCRIPTION
## Summary

`@geolonia/maps-core@^0.4.2`（[maps-core#90](https://github.com/geolonia/maps-core/pull/91)）を取り込み、`GeoloniaMap` コンストラクタが再び **CSS セレクタ文字列 / HTMLElement** を受け付けるようになったのを、embed バンドルの `window.geolonia.Map` 経由で守る e2e を追加します。

旧 embed 由来の呼び出し規約（`new geolonia.Map('#map')` など）が wrapper 越しに壊れていないことの回帰テストです。

## 変更点

- **deps**: `@geolonia/maps-core` `^0.4.1` → `^0.4.2`（#90 入り。`constructor(arg: string | HTMLElement | GeoloniaMapOptions)`）
- **version**: `6.0.0-pre.0` → `6.0.0-pre.1`
- **新規** `e2e/legacy-constructor.spec.ts`:
  - セレクタ文字列で構築 → その要素の `data-*`（lat/lng/zoom）を反映
  - HTMLElement で構築 → 同上
  - options オブジェクト → `data-*` を読まず options が優先（decoy の `data-zoom` を無視＝「object 素通し」契約を固定）
  - 存在しないセレクタ → `No HTML elements found` を throw
- **新規** `docs/e2e/legacy-constructor.html`: 上記用の bare コンテナ（`.geolonia` を付けず auto-scan と分離、`data-*` 付き）

## 補足（設計）

- `data-*` の読み取りは **legacy 形式（文字列/要素）のときだけ** maps-core#90 の legacy パスが行う。embed の parse-atts（auto-scan 経路）とは別レイヤ。よってコンテナに `.geolonia` を付けず、auto-render と混ざらない状態で検証している。
- 既存ヘルパ（`mockGeoloniaTiles` / `waitForStyleLoad` / `getCenter` / `getZoom` / `hasMapInstance`）をそのまま利用。maps-core 0.4.2 が `container.geoloniaMap = this` を設定するため、プログラム的構築でも既存ヘルパが機能する。実 API キー不要（モック完結）。

## Test plan

- [x] `npx eslint e2e/legacy-constructor.spec.ts` — clean
- [x] 新 spec 単体 — 4/4 pass
- [x] `npm run e2e`（Playwright, workers=1 = CI 相当）— **19 passed / 2 skipped**（skip は従来どおり iframe-no-key・pmtiles を maps-core/unit に委譲）、回帰なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **互換性**
  * 従来の地図生成方法（CSSセレクター、HTML要素、オプション指定）を引き続き利用できることを確認しました。
  * 無効なセレクター指定時に、適切なエラーが表示されることを確認しました。
* **テスト**
  * 実ブラウザ環境での地図表示と設定反映を検証するE2Eテストを追加しました。
* **リリース**
  * パッケージのプレリリース版を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->