### PR TITLE
docs: TypeDoc で EmbedAttributes の日本語 API リファレンスを生成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ typings/
 # secrets
 .envrc
 
+# TypeDoc API documentation output
+/api-docs
+
 # Others
 /dist
 /docs/embed

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,8 @@
         "style-loader": "^3.3.1",
         "svg-inline-loader": "^0.8.2",
         "ts-loader": "^9.4.3",
+        "typedoc": "^0.28.20",
+        "typedoc-plugin-markdown": "^4.12.0",
         "typescript": "^5.1.3",
         "vitest": "^4.1.1",
         "webpack": "^5.75.0",
@@ -583,6 +585,20 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "fflate": "^0.8.2"
+      }
+    },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1188,6 +1204,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1350,6 +1415,16 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -1507,6 +1582,13 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -6557,6 +6639,26 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
@@ -6645,6 +6747,13 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6698,6 +6807,47 @@
       "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
       "license": "ISC"
     },
+    "node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6707,6 +6857,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -7838,6 +7995,16 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9542,6 +9709,82 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.28.20",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.20.tgz",
+      "integrity": "sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.23.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.3.0",
+        "minimatch": "^10.2.5",
+        "yaml": "^2.9.0"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.12.0.tgz",
+      "integrity": "sha512-eJDEMAfxCmede22c/Jw7d0FA13ggAQv+KkwQYKYCdqI02cin6Rc9QRwbG/7XvvHWinuFejySnZVUWDtvGk3Vbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "typedoc": "0.28.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -9555,6 +9798,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
@@ -10484,6 +10734,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "format": "prettier \"./src/**/*.ts\" --write",
     "lint": "eslint .",
     "test": "vitest run",
-    "e2e": "playwright test"
+    "e2e": "playwright test",
+    "docs:api": "typedoc"
   },
   "author": "Geolonia (https://geolonia.com)",
   "repository": {
@@ -58,6 +59,8 @@
     "style-loader": "^3.3.1",
     "svg-inline-loader": "^0.8.2",
     "ts-loader": "^9.4.3",
+    "typedoc": "^0.28.20",
+    "typedoc-plugin-markdown": "^4.12.0",
     "typescript": "^5.1.3",
     "vitest": "^4.1.1",
     "webpack": "^5.75.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,9 +5,9 @@ import type { GeoloniaMap } from '@geolonia/maps-core';
  *
  * 各プロパティは kebab-case の `data-*` 属性に対応する（`markerColor` は
  * `data-marker-color`、`'3d'` は `data-3d`）。
- * `parseAtts` がコンテナの `dataset` を読み、以下に示す既定値を補ったうえで、
- * 各値を文字列（表示位置に関わるフィールドは数値）として保持する。
- * on/off のフラグはリテラル文字列 `'on'` / `'off'` である。
+ * `parseAtts` がコンテナの `dataset` を読み、以下に示す既定値を補う。
+ * `data-*` で指定された値は文字列のまま保持され、未指定の数値フィールドには
+ * 数値の既定値が入る。on/off のフラグはリテラル文字列 `'on'` / `'off'` である。
  * この形はそのまま登録済みの {@link EmbedPlugin} に渡されるため、後方互換のために
  * 構造を安定させている。地図自体はこの値から `attsToOptions` を経て構築される。
  */
@@ -128,9 +128,11 @@ export type EmbedAttributes = {
    */
   style: string;
   /**
-   * `data-lang`：ラベルの言語。`'ja'`、`'en'`、または `'auto'`（ブラウザの言語に
-   * 従う）。`ja` / `ja-jp` のみ日本語に解決され、それ以外の値は英語に解決される。
-   * @defaultValue `'auto'`
+   * `data-lang`：ラベルの言語。`data-lang` に指定できるのは `'ja'`、`'en'`、
+   * `'auto'` など。`parseAtts` は `'ja'` のみを `'ja'` に解決し、それ以外の明示値は
+   * `'en'` に解決する（`'ja-jp'` も `'en'` になる）。`'auto'` および未指定のときは
+   * ブラウザ言語（`getLang()` の結果。`'ja'` または `'en'`）になる。
+   * @defaultValue 未指定のときは `getLang()` の結果（`'ja'` または `'en'`）
    */
   lang: string;
   /**
@@ -177,8 +179,13 @@ export type EmbedAttributes = {
 };
 
 /**
- * 埋め込みプラグインの型。地図の生成後に、地図インスタンス、対象のコンテナ要素、
- * 正規化済みの {@link EmbedAttributes} を受け取って呼び出される。
+ * 埋め込みプラグインの型。地図インスタンス、対象のコンテナ要素、正規化済みの
+ * {@link EmbedAttributes} を受け取って呼び出される。
+ *
+ * 呼び出しのタイミングは地図の生成時点で異なる。`DOMContentLoaded` 後に生成された
+ * 地図では生成直後に呼び出される。それ以前に生成された地図では `DOMContentLoaded`
+ * まで保留され、そのイベント時にまとめて呼び出される。呼び出し前に削除された地図に
+ * 対しては呼び出されない。
  */
 export type EmbedPlugin<
   PluginAttributes extends { [otherKey: string]: string } = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,38 +1,185 @@
 import type { GeoloniaMap } from '@geolonia/maps-core';
 
+/**
+ * `.geolonia` の地図コンテナから読み取った `data-*` 属性を正規化した形。
+ *
+ * 各プロパティは kebab-case の `data-*` 属性に対応する（`markerColor` は
+ * `data-marker-color`、`'3d'` は `data-3d`）。
+ * `parseAtts` がコンテナの `dataset` を読み、以下に示す既定値を補ったうえで、
+ * 各値を文字列（表示位置に関わるフィールドは数値）として保持する。
+ * on/off のフラグはリテラル文字列 `'on'` / `'off'` である。
+ * この形はそのまま登録済みの {@link EmbedPlugin} に渡されるため、後方互換のために
+ * 構造を安定させている。地図自体はこの値から `attsToOptions` を経て構築される。
+ */
 export type EmbedAttributes = {
+  /**
+   * `data-lat`：地図中心の緯度。中心は `data-lat` と `data-lng` の両方が
+   * 指定されたときにのみ適用される。
+   * @defaultValue `0`
+   */
   lat: string | number;
+  /**
+   * `data-lng`：地図中心の経度。{@link EmbedAttributes.lat} を参照。
+   * @defaultValue `0`
+   */
   lng: string | number;
+  /**
+   * `data-zoom`：初期ズームレベル。
+   * @defaultValue `0`
+   */
   zoom: string | number;
+  /**
+   * `data-bearing`：初期方位（回転）。単位は度。
+   * @defaultValue `0`
+   */
   bearing: string | number;
+  /**
+   * `data-pitch`：初期ピッチ（傾き）。単位は度。
+   * @defaultValue `0`
+   */
   pitch: string | number;
+  /**
+   * `data-hash`（`'on'` / `'off'`）：地図の表示位置を URL のハッシュに同期する。
+   * @defaultValue `'off'`
+   */
   hash: string;
+  /**
+   * `data-marker`（`'on'` / `'off'`）：中心にマーカーを表示する。中心が設定されて
+   * いるときにのみ有効（{@link EmbedAttributes.lat} を参照）。
+   * @defaultValue `'on'`
+   */
   marker: string;
+  /**
+   * `data-marker-color`：中心マーカーの色。
+   * @defaultValue `'#E4402F'`
+   */
   markerColor: string;
+  /**
+   * `data-open-popup`（`'on'` / `'off'`）：読み込み時にマーカーのポップアップを開く。
+   * @defaultValue `'off'`
+   */
   openPopup: string;
+  /**
+   * `data-custom-marker`：マーカーとして使う要素の CSS セレクタ。
+   * @defaultValue `''`
+   */
   customMarker: string;
+  /**
+   * `data-custom-marker-offset`：マーカーのオフセット。`"x, y"` 形式のピクセル値。
+   * @defaultValue `'0, 0'`
+   */
   customMarkerOffset: string;
+  /**
+   * `data-gesture-handling`（`'on'` / `'off'`）：パン、ズーム、回転のジェスチャを
+   * 有効にする。地図を非インタラクティブに生成した場合は `'off'` に固定される。
+   * @defaultValue `'on'`
+   */
   gestureHandling: string;
+  /**
+   * `data-navigation-control`：ズームと回転のコントロール。`'on'` / `'off'`、または
+   * 表示位置（`'top-right'`、`'bottom-left'` など）を受け付ける。
+   * @defaultValue `'on'`
+   */
   navigationControl: string;
+  /**
+   * `data-geolocate-control`：現在地コントロール。`'on'` / `'off'`、または表示位置を
+   * 受け付ける。
+   * @defaultValue `'off'`
+   */
   geolocateControl: string;
+  /**
+   * `data-fullscreen-control`：全画面コントロール。`'on'` / `'off'`、または表示位置を
+   * 受け付ける。
+   * @defaultValue `'off'`
+   */
   fullscreenControl: string;
+  /**
+   * `data-scale-control`：スケールバー。`'on'` / `'off'`、または表示位置を受け付ける。
+   * @defaultValue `'off'`
+   */
   scaleControl: string;
+  /**
+   * `data-geolonia-control`：Geolonia のアトリビューション（ロゴ）コントロール。
+   * `'on'` / `'off'`、または表示位置を受け付ける。
+   * @defaultValue `'on'`
+   */
   geoloniaControl: string;
+  /**
+   * `data-geojson`：GeoJSON のソース。URL、インラインの JSON 文字列、または
+   * インライン要素（`<script type="application/json">` など）を指す CSS セレクタの
+   * いずれか。
+   * @defaultValue `''`
+   */
   geojson: string;
+  /**
+   * `data-cluster`（`'on'` / `'off'`）：GeoJSON のポイント地物をクラスタリングする。
+   * @defaultValue `'on'`
+   */
   cluster: string;
+  /**
+   * `data-cluster-color`：クラスタ化されたポイントマーカーの色。
+   * @defaultValue `'#ff0000'`
+   */
   clusterColor: string;
+  /**
+   * `data-style`：地図スタイル。Geolonia のスタイル名（`geolonia/basic-v2`）、
+   * style.json の完全な URL、または相対パスのいずれか。
+   * @defaultValue `'geolonia/basic-v2'`
+   */
   style: string;
+  /**
+   * `data-lang`：ラベルの言語。`'ja'`、`'en'`、または `'auto'`（ブラウザの言語に
+   * 従う）。`ja` / `ja-jp` のみ日本語に解決され、それ以外の値は英語に解決される。
+   * @defaultValue `'auto'`
+   */
   lang: string;
+  /**
+   * `data-plugin`：実行する埋め込みプラグイン名。無効にする場合は `'off'`。
+   * @defaultValue `'off'`
+   */
   plugin: string;
+  /**
+   * `data-key`：Geolonia の API キー（埋め込み `<script>` タグの
+   * `?geolonia-api-key=` クエリで指定しない場合に使う）。
+   * @defaultValue キーリングが保持する現在の API キー
+   */
   key: string;
+  /**
+   * `data-api-url`：Geolonia API のエンドポイントのベース URL。
+   * @defaultValue `` `https://api.geolonia.com/${stage}` ``
+   */
   apiUrl: string;
+  /**
+   * `data-loader`（`'on'` / `'off'`）：地図の初期化中にローディング表示を出す。
+   * @defaultValue `'on'`
+   */
   loader: string;
+  /**
+   * `data-min-zoom`：最小ズームレベル。空文字列は「未指定」を意味する。
+   * @defaultValue `''`
+   */
   minZoom: string | number;
+  /**
+   * `data-max-zoom`：最大ズームレベル。
+   * @defaultValue `20`
+   */
   maxZoom: string | number;
+  /**
+   * `data-3d`（`'on'` / `'off'`）：3D 建物を描画する。
+   * @defaultValue `''`（off として扱われる）
+   */
   '3d': string;
+  /**
+   * 追加の `data-*` 属性はそのまま透過される（{@link EmbedPlugin} が利用する
+   * プラグイン固有の属性など）。
+   */
   [otherKey: string]: string | number;
 };
 
+/**
+ * 埋め込みプラグインの型。地図の生成後に、地図インスタンス、対象のコンテナ要素、
+ * 正規化済みの {@link EmbedAttributes} を受け取って呼び出される。
+ */
 export type EmbedPlugin<
   PluginAttributes extends { [otherKey: string]: string } = {
     [otherKey: string]: string;

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "plugin": ["typedoc-plugin-markdown"],
+  "entryPoints": ["src/types.ts"],
+  "out": "api-docs",
+  "excludePrivate": true,
+  "excludeInternal": true,
+  "excludeExternals": true,
+  "readme": "none",
+  "githubPages": false,
+  "disableSources": true,
+  "flattenOutputFiles": true
+}


### PR DESCRIPTION
## 概要

`data-*` 属性の型 `EmbedAttributes` / `EmbedPlugin` に日本語 TSDoc を付与し、TypeDoc で Markdown の API リファレンスを生成できるようにします。埋め込み利用者が最も参照する「どの `data-*` 属性が何を意味し、既定値は何か」を日本語で一覧できるようにするのが狙いです。

差分を小さく保つため、今回は `src/types.ts` のみにコメントを追加し、TypeDoc の entrypoint も `src/types.ts` に絞っています。

## 変更点

- `typedoc.json` を追加（`typedoc-plugin-markdown` で Markdown 出力。設定は maps-suite に準拠）
- `package.json` に `docs:api` スクリプトと `typedoc` / `typedoc-plugin-markdown` を追加
- `.gitignore` に生成先 `/api-docs` を追加
- `src/types.ts` の各 `data-*` 属性に説明と既定値を日本語 TSDoc で付与（型構造は変更なし）

## 生成方法

```
npm run docs:api
```

`api-docs/` 配下に `README.md` / `TypeAlias.EmbedAttributes.md` / `TypeAlias.EmbedPlugin.md` が生成されます。

## 確認

- `npm run lint` パス
- `npm run test` パス（15 件）
- `npm run docs:api` を警告ゼロで生成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - APIドキュメントを生成するコマンドを追加しました。
  - Markdown形式のAPIドキュメントを`api-docs`ディレクトリへ出力できます。

- **ドキュメント**
  - 公開型や埋め込みプラグインの説明を拡充しました。
  - APIドキュメント生成時の対象や出力形式を設定しました。

- **メンテナンス**
  - 生成されたAPIドキュメントがバージョン管理の対象にならないようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->