### PR TITLE
chore: maps-core 0.4.3 / embed 6.0.0-pre.2 へバンプ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.0.0-pre.2",
       "license": "MIT",
       "dependencies": {
-        "@geolonia/maps-core": "^0.4.2",
+        "@geolonia/maps-core": "^0.4.3",
         "@playwright/test": "^1.61.1",
         "maplibre-gl": "5.19.0"
       },
@@ -505,9 +505,9 @@
       }
     },
     "node_modules/@geolonia/maps-core": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@geolonia/maps-core/-/maps-core-0.4.2.tgz",
-      "integrity": "sha512-xH5pobfedxl4tTgiAqwT63x6c/TEi5dKKgIUV8MQGZDr70n+9UpYtfjowGAig6VkOM96m55a7YaVexGvL2XKkw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@geolonia/maps-core/-/maps-core-0.4.3.tgz",
+      "integrity": "sha512-rQJFWTdNVtGD3daHh0zUPRRqqFoecCED6/KItpu3yy6wYBrBK5G2eS3Ol+lW3nVWwKc4qA+/4VF8ggGnSimjuw==",
       "license": "MIT",
       "dependencies": {
         "@geolonia/maplibre-gesture-handling": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/embed",
-  "version": "6.0.0-pre.1",
+  "version": "6.0.0-pre.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/embed",
-      "version": "6.0.0-pre.1",
+      "version": "6.0.0-pre.2",
       "license": "MIT",
       "dependencies": {
         "@geolonia/maps-core": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/embed",
-  "version": "6.0.0-pre.1",
+  "version": "6.0.0-pre.2",
   "description": "Geolonia embed JS API",
   "main": "dist/embed.js",
   "types": "dist/src/embed.d.ts",
@@ -69,7 +69,7 @@
     "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
-    "@geolonia/maps-core": "^0.4.2",
+    "@geolonia/maps-core": "^0.4.3",
     "@playwright/test": "^1.61.1",
     "maplibre-gl": "5.19.0"
   }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '6.0.0-pre.0';
+export const VERSION = '6.0.0-pre.2';


### PR DESCRIPTION
## Summary

`@geolonia/maps-core` を `^0.4.3` に、embed を `6.0.0-pre.2` に上げます。

maps-core 0.4.3 は npm に publish 済み（[v0.4.3](https://github.com/geolonia/maps-core/releases/tag/v0.4.3)）で、lockfile も 0.4.3 に解決済みです。

## 変更点

- `package.json`: `@geolonia/maps-core` `^0.4.2` → `^0.4.3`、version `6.0.0-pre.1` → `6.0.0-pre.2`
- `package-lock.json`: maps-core を 0.4.3 に解決、ルートの version フィールドを `pre.2` に更新
- `src/version.ts`: `build:version` で再生成（master 上で `pre.0` のまま stale だったため `pre.2` に是正）

## Test plan

すべてローカルで 0.4.3 に対して実行済み:

- [x] `npm run lint` — clean
- [x] `npm test` — 15 passed
- [x] `npm run build` — embed.js + embed-core.js 生成成功
- [x] `npm run e2e`（workers=1 = CI 相当）— **19 passed / 2 skipped**
- [x] **legacy コンストラクタ（maps-core#90）の e2e 4件が 0.4.3 でも green** — セレクタ文字列 / HTMLElement / options 素通し / 存在しないセレクタで throw

## Note

- e2e の 2 skipped は本 PR で増えたものではなく、#500 から継続している既存 skip（iframe 拒否パス / pmtiles プロトコル登録）。別途 issue 化して扱う。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * パッケージのプレリリースバージョンを **6.0.0-pre.2** に更新しました。
  * アプリケーション内で表示されるバージョン情報を最新のリリース番号に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->