### PR TITLE
docs(changelog): v6 セクションをリリース実態に合わせる

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 ## @geolonia/embed
 
-### v6.0.0-pre.0
+### v6.0.0-pre.2
 
 コア実装を `@geolonia/maps-core` に委譲し、embed は「HTML 埋め込みラッパー」に専念する構成へ移行しました。
 
 - **Refactor**: 地図コア（`GeoloniaMap` / `GeoloniaMarker` / `SimpleStyle` / `SimpleStyleVector` / `keyring` / attribution・logo コントロール等）を [`@geolonia/maps-core`](https://github.com/geolonia/maps-core) に移管。embed 側には `data-*` 属性のパースと DOM 自動走査・遅延読み込み・プラグイン機構といったラッパー機能のみを残しました。
-- **Breaking**: `GeoloniaMap` コンストラクタは `GeoloniaMapOptions` オブジェクトのみを受け取ります。DOM 要素や CSS セレクタ文字列の直接指定は廃止されました（`new geolonia.Map({ container })` を使用してください）。
+- **Compat**: `GeoloniaMap` コンストラクタは `GeoloniaMapOptions` オブジェクト形式（`new geolonia.Map({ container })`）を推奨しますが、旧 embed 互換として CSS セレクタ文字列（`new geolonia.Map('#map')`）や HTMLElement の直接指定も引き続き受け付けます（[maps-core#90](https://github.com/geolonia/maps-core/issues/90)）。legacy 形式ではコンテナの `data-*` 属性を読み取って options に反映します。
 - **Breaking**: `keyring.parse()`（DOM スキャン）は廃止されました。API キーは `<script src="...?geolonia-api-key=KEY">` から embed が読み取り、`keyring.setApiKey()` で maps-core に渡します（既存の script タグ方式は引き続き動作します）。
 - **Internal**: maps-core が内包する依存（pmtiles / sanitize-html / tinycolor2 / turf / gesture-handling 等）を embed の直接依存から削除しました。
+- **Internal**: `@geolonia/maps-core` `^0.4.3` に依存します。
 
 ### nightly
 


### PR DESCRIPTION
## Summary

CHANGELOG の v6 セクションが、実際に publish したもの（`v6.0.0-pre.2`）と食い違っていたので修正します。

## 修正内容

### 1. 見出しを実在する版に

`### v6.0.0-pre.0` → `### v6.0.0-pre.2`

pre.0 / pre.1 はタグを打っておらず npm / CDN には存在しません（v6 の最初のリリースが pre.2）。見出しだけが実在しない版を指していました。

### 2. コンストラクタの項: Breaking → Compat（重要）

修正前:
> **Breaking**: `GeoloniaMap` コンストラクタは `GeoloniaMapOptions` オブジェクトのみを受け取ります。DOM 要素や CSS セレクタ文字列の直接指定は廃止されました

[maps-core#90](https://github.com/geolonia/maps-core/issues/90)（maps-core 0.4.2 以降）で **CSS セレクタ文字列 / HTMLElement を受け付ける後方互換が復活**しているため、この記述は公開物の挙動と**逆**でした。実際に公開した `v6.0.0-pre.2` のバンドルでも `new geolonia.Map('#map')` と要素渡しが動作します（embed 側 e2e 4件 / maps-core 側 unit 11件 + e2e 2件で担保）。

修正後は options 形式を推奨としつつ、legacy 形式（＋そのとき `data-*` を読むこと）も受け付ける旨に書き換えています。

### 3. maps-core `^0.4.3` 依存を追記

## Note

- `keyring.parse()` 廃止の項は現在も有効なので Breaking のまま維持しています。
- README は options 形式の例を示すだけで「廃止」の記述はなく、同種の不整合はありませんでした。

## Test plan

- [x] `npm run lint` — clean（ドキュメントのみの変更）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * `@geolonia/embed` v6.0.0-pre.2 の変更内容を更新しました。
  * コア機能の移管範囲と、ラッパー機能（`data-*` 属性の解析、DOM の自動検出・遅延読み込み、プラグイン機構）を明確化しました。
  * 旧 embed との互換性として、CSS セレクターや HTMLElement を指定できることを追記しました。
  * API キーの設定方法と関連する移行情報を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->