### PR TITLE
chore: @geolonia/maps-core を ^0.5.0 に追従

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.0.0-pre.2",
       "license": "MIT",
       "dependencies": {
-        "@geolonia/maps-core": "^0.4.3",
+        "@geolonia/maps-core": "^0.5.0",
         "@playwright/test": "^1.61.1",
         "maplibre-gl": "5.19.0"
       },
@@ -505,9 +505,9 @@
       }
     },
     "node_modules/@geolonia/maps-core": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@geolonia/maps-core/-/maps-core-0.4.3.tgz",
-      "integrity": "sha512-rQJFWTdNVtGD3daHh0zUPRRqqFoecCED6/KItpu3yy6wYBrBK5G2eS3Ol+lW3nVWwKc4qA+/4VF8ggGnSimjuw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@geolonia/maps-core/-/maps-core-0.5.0.tgz",
+      "integrity": "sha512-gQ09XsKgnHt5q4u0KuofcJz5Gn+mxBuSlb+lrpoc1CPYBBb7ihUOizNEanlhtBuUbTp7AV1XVv6cW8qax8hK4g==",
       "license": "MIT",
       "dependencies": {
         "@geolonia/maplibre-gesture-handling": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
-    "@geolonia/maps-core": "^0.4.3",
+    "@geolonia/maps-core": "^0.5.0",
     "@playwright/test": "^1.61.1",
     "maplibre-gl": "5.19.0"
   }


### PR DESCRIPTION
## Summary

[maps-core#99](https://github.com/geolonia/maps-core/pull/99)（keyring の stage 既定値を `"dev"` → `"v1"`（本番）に変更、v0.5.0）に追従します。`^0.4.3` は 0.5.0 を含まないため、range を明示的に上げています。

依存の更新のみで、embed 側のコード変更はありません。

## embed への影響

stage の決まり方が2経路あり、片方だけ既定値の変更を受けます。

| 経路 | stage の決まり方 | 0.5.0 での変化 |
|---|---|---|
| `<script src="...?geolonia-api-key=KEY">` | `parseScriptTagApiKey` が `MAP_PLATFORM_STAGE \|\| 'dev'` を返し、`render` が `keyring.setStage()` を呼ぶ | **なし**（既定値は参照されない） |
| `data-key` のみ（script タグにキーなし） | `parseScriptTagApiKey` が `null` を返し `setStage` が呼ばれないため、keyring の既定値が効く | **`dev` → `v1`**（本番を向くようになる） |

後者は「渡し忘れると黙って dev を叩く」という maps-core#99 が解こうとしていた問題そのもので、変化の方向は改善です。実測で `keyring.stage`（fresh / `reset()` 後とも）が `"v1"`、embed が導出する apiUrl が `https://api.geolonia.com/v1` になることを確認しました。

## Test plan

すべて 0.5.0 に対して実行済み:

- [x] `npm run lint` — clean
- [x] `npm test` — 15 passed
- [x] `npm run build` — embed.js + embed-core.js 生成成功
- [x] `npm run e2e`（workers=1 = CI 相当）— **19 passed / 2 skipped**（legacy コンストラクタ 4件も green）

## Note

- embed のバージョンは据え置き（`6.0.0-pre.2`）です。CDN / npm へ出す段階でバンプします。
- unit test は `keyring.setStage('v1')` を明示しているため、stage 既定値の変更自体は検知しません（上記のとおり実測で確認）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 地図機能の基盤ライブラリを更新し、最新の改善を取り込みました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->