### PR TITLE
fix(v1): *.tiles.geolonia.com に API キーと sessionId を付与する（#450 のバックポート）

### DIFF
--- a/src/lib/geolonia-map.ts
+++ b/src/lib/geolonia-map.ts
@@ -8,7 +8,7 @@ import parseAtts from './parse-atts';
 import { SimpleStyle } from './simplestyle';
 import SimpleStyleVector from './simplestyle-vector';
 
-import { getContainer, getOptions, getSessionId, getStyle, handleRestrictedMode, isScrollable, parseControlOption, parseSimpleVector, handleErrorMode } from './util';
+import { getContainer, getOptions, getSessionId, getStyle, handleRestrictedMode, isScrollable, parseControlOption, parseSimpleVector, handleErrorMode, isGeoloniaTilesHost } from './util';
 
 import type { MapOptions, PointLike, StyleOptions, StyleSpecification, StyleSwapOptions } from 'maplibre-gl';
 
@@ -111,9 +111,13 @@ export default class GeoloniaMap extends maplibregl.Map {
       }
 
       const transformedUrlObj = new URL(transformedUrl);
+      const geoloniaTilesHost = isGeoloniaTilesHost(transformedUrlObj);
 
-      if (resourceType === 'Source' && transformedUrl.startsWith('https://tileserver.geolonia.com')) {
-        if (atts.stage !== 'v1') {
+      if (resourceType === 'Source' && geoloniaTilesHost) {
+        // NOTE: Only the legacy `tileserver.geolonia.com` has per-stage hosts.
+        // `*.tiles.geolonia.com` must be left as-is, otherwise a non-v1 stage
+        // would rewrite it to `tileserver-<stage>.geolonia.com` and lose the host.
+        if (atts.stage !== 'v1' && transformedUrlObj.hostname === 'tileserver.geolonia.com') {
           transformedUrlObj.hostname = `tileserver-${atts.stage}.geolonia.com`;
         }
         transformedUrlObj.searchParams.set('sessionId', sessionId);

--- a/src/lib/util.test.ts
+++ b/src/lib/util.test.ts
@@ -2,7 +2,7 @@
 
 import assert from 'assert';
 import { JSDOM } from 'jsdom';
-import { getContainer, getLang, getOptions, getStyle, handleMarkerOptions, isDomElement, isURL, parseControlOption, parseSimpleVector, sanitizeDescription } from './util';
+import { getContainer, getLang, getOptions, getStyle, handleMarkerOptions, isDomElement, isGeoloniaTilesHost, isURL, parseControlOption, parseSimpleVector, sanitizeDescription } from './util';
 
 const base = 'https://base.example.com/parent/';
 
@@ -45,6 +45,29 @@ describe('Tests for util.js', () => {
 
   it('Name should not be detected', () => {
     assert.deepEqual(false, isURL('example.com/hello'));
+  });
+
+  describe('isGeoloniaTilesHost', () => {
+    it('detects primary tileserver hostname', () => {
+      const url =
+        'https://tileserver.geolonia.com/v3/tiles.json?key=YOUR-API-KEY';
+      assert.strictEqual(isGeoloniaTilesHost(url), true);
+    });
+
+    it('detects tiles.geolonia.com subdomains (v2)', () => {
+      const url = new URL('https://osm.v2.tiles.geolonia.com/tiles.json');
+      assert.strictEqual(isGeoloniaTilesHost(url), true);
+    });
+
+    it('detects tiles.geolonia.com subdomains (v3)', () => {
+      const url = new URL('https://osm.v3.tiles.geolonia.com/tiles.json');
+      assert.strictEqual(isGeoloniaTilesHost(url), true);
+    });
+
+    it('returns false for other hosts or invalid urls', () => {
+      assert.strictEqual(isGeoloniaTilesHost('https://example.com/tiles'), false);
+      assert.strictEqual(isGeoloniaTilesHost('not-a-url'), false);
+    });
   });
 
   it('should detect the object is DOM correctly', () => {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -23,6 +23,20 @@ export function isURL(str) {
   return false;
 }
 
+export function isGeoloniaTilesHost(url: string | URL): boolean {
+  try {
+    const urlObj = typeof url === 'string' ? new URL(url) : url;
+
+    return (
+      // NOTE: geolonia use tileserver.geolonia.com or *.tiles.geolonia.com for tile server. Other domains is NOT allowed.
+      urlObj.hostname === 'tileserver.geolonia.com' ||
+      urlObj.hostname.endsWith('.tiles.geolonia.com')
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function checkPermission() {
   // It looks that isn't iFrame, so returs true.
   if (window.self === window.parent) {


### PR DESCRIPTION
#508 の対応です。**base は `master` ではなく `maintenance/v1`** です。

> ⚠️ **Draft**: #510（`maintenance/v1` から CI を切り離す）のマージを待っています。現状このブランチにはまだ workflow があり、リリース時にタグを打つと `npm publish --access=public` が走って npm の `latest` が 4.3.x に置き換わるためです。

## 変更

| ファイル | 内容 |
|---|---|
| `src/lib/util.ts` | `isGeoloniaTilesHost()` を追加（#450 と同一実装） |
| `src/lib/geolonia-map.ts` | Source の判定を前方一致から `isGeoloniaTilesHost()` へ。あわせて**ホスト書き換えを従来ホストに限定** |
| `src/lib/util.test.ts` | テスト4件追加 |

## v1 固有の調整（#450 には無い変更）

ホスト書き換えの条件が v1 と master で異なります。

| | 条件 |
|---|---|
| v1 | `atts.stage !== 'v1'` → `tileserver-<stage>.geolonia.com` に書き換え |
| master | `atts.stage === 'dev'` のときだけ |

判定を `isGeoloniaTilesHost()` に広げるだけだと、この分岐に `*.tiles.geolonia.com` が入ってきて、**stage が v1 以外のとき `osm.v2.tiles.geolonia.com` が `tileserver-<stage>...` に書き換えられてホストを失います**。そこで書き換えを従来ホストに限定しました。

```diff
- if (atts.stage !== 'v1') {
+ if (atts.stage !== 'v1' && transformedUrlObj.hostname === 'tileserver.geolonia.com') {
    transformedUrlObj.hostname = `tileserver-${atts.stage}.geolonia.com`;
  }
```

## 検証結果

### 実サーバでの検証（最重要）— 適用前は顧客ドメインで表示されない

自前サーバ（実キーの許可オリジンに追加済み）で検証しました。

| ビルド | style | キー | 結果 |
|---|---|---|---|
| 適用前 | basic-v1（既定） | 実キー | **OK** |
| 適用前 | **basic-v2** | 実キー | **NG（表示されない）** |
| 適用後 | basic-v1（既定） | 実キー | OK |
| 適用後 | basic-v2 | 実キー | OK |
| 前後とも | 両方 | `YOUR-API-KEY` | **すべて NG** |

適用前の basic-v2 が NG になるのは、送信される key が `YOUR-API-KEY` であり、**デモキーが顧客ドメインのオリジンを許可していない**ためです（最下行がその裏づけ）。つまりこれは集計漏れではなく、**`*.tiles.geolonia.com` を参照する style を指定した利用者の地図が実ドメインで表示されない**という機能不全でした。

既定スタイル（basic-v1）は前後とも OK なので、**既定のまま使っている限り無影響＝デグレなし**です。

> ⚠️ **localhost では問題が隠れます。** localhost は開発用にデモキーの許可オリジンに入っているため、適用前でも basic-v2 が表示されてしまいます。検証は**実ドメイン + 実キー**で行う必要があります。

### 送信された key の差（原因）

`osm.v2.tiles.geolonia.com/tiles.json` へのリクエスト:

| | key | sessionId |
|---|---|---|
| 適用前 | **`YOUR-API-KEY`（style JSON のプレースホルダのまま）** | なし |
| 適用後 | **実キー** | あり |

Geolonia の style JSON は全ソースが `?key=YOUR-API-KEY` を**プレースホルダ**として持ち、embed の `transformRequest` が `searchParams.set('key', atts.key)` で実キーに上書きする設計です。適用前は `osm.v2` が判定に入らないため上書きされず、デモキーで通信していました。

同じ画面の従来経路（basic-v1 の `geolonia` / basic-v2 の `dem`）は前後とも実キーが入るため、**1 つの地図の中でキーが混在**していたことになります。

### デグレ確認（stage 別・ホスト書き換え）

| stage | 従来経路（既定 basic-v1） | `osm.v2`（basic-v2） |
|---|---|---|
| `dev` | `tileserver-dev.geolonia.com/...?key=&sessionId=`（書き換えあり＝従来どおり） | `osm.v2.tiles.geolonia.com/...`（**書き換えられず**ホスト保持） |
| `v1` | `tileserver.geolonia.com/...?key=&sessionId=` | `osm.v2.tiles.geolonia.com/...` |

どちらの stage でも既定スタイル経路に変化はありません。

### その他

- `mocha`: 39 passing（`isGeoloniaTilesHost` の新規4件を含む）
- `eslint`: エラー 0
- **production ビルドを配信中の `/v1/embed` と比較 → 差分は1箇所だけ**で、この変更そのもの（前後は完全一致）。Node 18.20.8 + yarn 1.22.22 `--frozen-lockfile` でビルドすると適用前は sha256 まで一致するため、差分が「入れた変更のみ」と断定できます

## この修正の意味

1. **実キーの権限・レート制限が適用される**（適用前はデモキーの枠で通信していた）
2. **アクセス集計が実キーに紐づく**（#450 の主目的）
3. **デモキー依存から脱する** — 適用前は `YOUR-API-KEY` が停止・制限された瞬間に、顧客のキーとは無関係に表示が壊れる状態だった
4. basic-v2 固有ではなく **`*.tiles.geolonia.com` を参照する全 style** に効く。今後この系のホストを使う style が増えても v1 で穴が開かない

詳細な経緯は #508 の「検証で分かったこと（発見）」に記載しています。

## 検証手順（再現方法）

CI は使わない前提なので、手元で確認します。

```bash
# Node 18 が必要（.nvmrc = v18）
nvm use 18
yarn install --frozen-lockfile
yarn lint && yarn test && yarn build

# 本番相当の stage で確認するには /v1/embed のパスで配信する必要がある
# （keyring が script タグの pathname /vN/embed から stage を決めるため、
#   ./embed で読むと stage が dev に落ちる）
mkdir -p docs/v1 && cp dist/embed docs/v1/embed
npx webpack serve --config ./docs/webpack.config.js
```

検証ページ（`data-style` 指定なしと `geolonia/basic-v2` を並べたもの）は本 PR には含めていません。必要であれば追加します。

## 関連

- Closes #508
- #510（CI 切り離し）— マージ後に本 PR を Ready にします

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * タイルサーバーへのリクエスト判定を改善しました。
  * レガシーホストは環境に応じたホストへ適切に切り替え、現行のタイルホストはそのまま利用できるようになりました。
  * 無効なURLや対象外のホストを正しく判定できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

