### PR TITLE
chore: maps-core 0.5.1 への追従と v6.0.0-pre.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## @geolonia/embed
 
+### v6.0.0-pre.3
+
+- **Fix**: maplibre-gl 5.11.0 以降で帰属表示が空になる問題を修正しました（[#512](https://github.com/geolonia/embed/issues/512)）。ソースに指定した `attribution` だけでなく、ベーススタイルの `© Geolonia` / `© OpenStreetMap` も表示されない状態でした。修正の実体は [maps-core#102](https://github.com/geolonia/maps-core/pull/102) で、embed 側は依存を更新して取り込みます。
+- **Internal**: `@geolonia/maps-core` `^0.5.1` に依存します。
+
 ### v6.0.0-pre.2
 
 コア実装を `@geolonia/maps-core` に委譲し、embed は「HTML 埋め込みラッパー」に専念する構成へ移行しました。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@geolonia/embed",
-  "version": "6.0.0-pre.2",
+  "version": "6.0.0-pre.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/embed",
-      "version": "6.0.0-pre.2",
+      "version": "6.0.0-pre.3",
       "license": "MIT",
       "dependencies": {
-        "@geolonia/maps-core": "^0.5.0",
+        "@geolonia/maps-core": "^0.5.1",
         "@playwright/test": "^1.61.1",
         "maplibre-gl": "5.19.0"
       },
@@ -505,9 +505,9 @@
       }
     },
     "node_modules/@geolonia/maps-core": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@geolonia/maps-core/-/maps-core-0.5.0.tgz",
-      "integrity": "sha512-gQ09XsKgnHt5q4u0KuofcJz5Gn+mxBuSlb+lrpoc1CPYBBb7ihUOizNEanlhtBuUbTp7AV1XVv6cW8qax8hK4g==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@geolonia/maps-core/-/maps-core-0.5.1.tgz",
+      "integrity": "sha512-T/pswEk8f1msZ5b3n55lNPINrfCdoSXuVNVhMgk+AJUfBzkCTjyQ9Zv8GY0IYwWyHHQ8TmDEW/hWHxBvrQhNTQ==",
       "license": "MIT",
       "dependencies": {
         "@geolonia/maplibre-gesture-handling": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/embed",
-  "version": "6.0.0-pre.2",
+  "version": "6.0.0-pre.3",
   "description": "Geolonia embed JS API",
   "main": "dist/embed.js",
   "types": "dist/src/embed.d.ts",
@@ -69,7 +69,7 @@
     "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
-    "@geolonia/maps-core": "^0.5.0",
+    "@geolonia/maps-core": "^0.5.1",
     "@playwright/test": "^1.61.1",
     "maplibre-gl": "5.19.0"
   }


### PR DESCRIPTION
Closes #512
Closes #513

`@geolonia/maps-core` を 0.5.1 に更新し、v6.0.0-pre.3 とします。

## 変更内容

- `dependencies` の `@geolonia/maps-core` を `^0.5.0` から `^0.5.1` へ
- バージョンを 6.0.0-pre.2 から 6.0.0-pre.3 へ
- CHANGELOG に v6.0.0-pre.3 の項を追加

レンジも上げています。`^0.5.0` のままでもロックファイルの更新で 0.5.1 は入りますが、利用者の環境に 0.5.0 が残っている場合に修正が入りません。

## 取り込む修正

#512 の帰属表示の再発です。修正の実体は geolonia/maps-core#102（geolonia/maps-core#101）で、`CustomAttributionControl` が maplibre-gl 5.11.0 以降で常に空になっていました。embed は maplibre-gl を 5.19.0 に固定しているため、v6 系はこの影響を受けていました。

## 確認したこと

- `npm run build` 成功
- `npm test` 15 passed
- `npx playwright test` 19 passed / 2 skipped
- `npm run lint` 指摘なし

## #513 に書いた e2e の復活について

#513 で「2026-06-08 に削除した帰属表示の E2E を戻す」ことを提案しましたが、**この PR には含めません。提案自体を取り下げます。**

帰属表示は maps-core の仕様であり、embed は委譲しているだけです。embed 側にテストを置くのは層をまたいだ重複で、削除の判断自体は正しかったと考え直しました。

再発の原因はテストを消したことではなく、移管先の maps-core が `peerDependencies: ^5.0.0` を宣言しながら devDependencies を 5.7.0 に固定し、**サポート範囲の片端しか回していなかった**ことです。maps-core#102 で 5.24.0 に上がりましたが、今度は上端だけになっており、範囲を回す仕組みは依然ありません。embed にテストを戻しても、次の変更が embed の固定版（5.19.0）だけに当たれば同じことが起きます。

対処すべきは maps-core 側のバージョンマトリクスなので、そちらに issue を立てます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * maplibre-gl 5.11.0以降で地図の帰属表示が空になる問題を修正しました。
* **変更**
  * パッケージをバージョン6.0.0-pre.3へ更新しました。
  * 地図機能の依存パッケージを更新しました。
  * 変更内容を変更履歴に追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->