### PR TITLE
fix(error): WebGL 初期化失敗時の表示を行動につながる内容にする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,10 @@ name: build
 
 on:
   push:
-    branches: [master]
+    branches: [master, 'maintenance/**']
     tags: ['*']
   pull_request:
-    branches: [master]
+    branches: [master, 'maintenance/**']
 
 jobs:
   act-test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,12 @@ name: build
 
 on:
   push:
-    branches: [master, 'maintenance/**']
+    # v5 は LTS なので GitHub Actions でリリースする。
+    # maintenance/v1 は手動リリースに移行したため、意図的に含めていない。
+    branches: [master, maintenance/v5]
     tags: ['*']
   pull_request:
-    branches: [master, 'maintenance/**']
+    branches: [master, maintenance/v5]
 
 jobs:
   act-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### nightly
 
 - **Improvement**: The message shown when the map fails to initialize (typically no WebGL) now tells the visitor what to try (restart the browser, restart the device, try another browser, update the graphics driver, contact the site owner). The developer-tools sentence was removed, and the message is shortened automatically on small map containers.
-- **Feature**: `data-error-message` (`errorMessage` in the programmatic API) replaces that message with your own text, or disables the error display entirely with `off`. The value is rendered as plain text.
+- **Feature**: `data-error-message` (`errorMessage` in the programmatic API) replaces that message with your own text, or disables the error display entirely with `off` (`false` in the programmatic API). The value is rendered as plain text.
 - **Fix**: The loading animation is now removed when the map fails to initialize.
 
 - **Feature**: Added support for external style.json URLs in `data-style` attribute

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### nightly
 
+- **Improvement**: The message shown when the map fails to initialize (typically no WebGL) now tells the visitor what to try (restart the browser, restart the device, try another browser, update the graphics driver, contact the site owner). The developer-tools sentence was removed, and the message is shortened automatically on small map containers.
+- **Feature**: `data-error-message` (`errorMessage` in the programmatic API) replaces that message with your own text, or disables the error display entirely with `off`. The value is rendered as plain text.
+- **Fix**: The loading animation is now removed when the map fails to initialize.
+
 - **Feature**: Added support for external style.json URLs in `data-style` attribute
   - You can now specify full URLs: `data-style="https://tile.openstreetmap.jp/styles/osm-bright/style.json"`
   - Relative paths are also supported: `data-style="./custom-style.json"`

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Use `data-error-message` to take over that message:
 ```
 
 The value is rendered as plain text; HTML is not interpreted. The same option is
-available to the programmatic API as `errorMessage`.
+available to the programmatic API as `errorMessage`, which also accepts `false`
+to disable the error display.
 
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -110,6 +110,32 @@ The `data-style` attribute accepts:
 
 You can see more examples at [https://geolonia.github.io/embed/](https://geolonia.github.io/embed/).
 
+### Error message when the map fails to initialize
+
+When the map cannot be initialized (typically because WebGL is unavailable on the
+device), the embed replaces the map with a message that tells the visitor what to
+try: restart the browser, restart the device, try another browser, update the
+graphics driver, and contact the site owner if it still fails. The message shrinks
+to a shorter version, and finally to the headline alone, as the map container gets
+smaller.
+
+Use `data-error-message` to take over that message:
+
+```html
+<!-- Replace the wording -->
+<div
+  class="geolonia"
+  data-error-message="Sorry, the map is unavailable. Please call 0120-000-000."
+></div>
+
+<!-- Show nothing at all, e.g. when the site renders its own fallback -->
+<div class="geolonia" data-error-message="off"></div>
+```
+
+The value is rendered as plain text; HTML is not interpreted. The same option is
+available to the programmatic API as `errorMessage`.
+
+
 # Contributing
 
 ## Development

--- a/docs/e2e/webgl-error.html
+++ b/docs/e2e/webgl-error.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="../style.css">
+  <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+  <title>@geolonia/embed - WebGL 初期化失敗時の表示</title>
+  <style>
+    body { font-family: sans-serif; margin: 1rem; }
+    .example { margin-bottom: 1.5rem; }
+    .geolonia { border: 1px solid #ccc; }
+  </style>
+  <script>
+    // WebGL が使えない端末を再現する（地図の初期化を必ず失敗させる）
+    const originalGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = function (type, ...args) {
+      if (typeof type === 'string' && type.indexOf('webgl') === 0) {
+        return null;
+      }
+      return originalGetContext.call(this, type, ...args);
+    };
+  </script>
+</head>
+<body>
+  <div class="example">
+    <h2>大きい地図（既定文言・手順つき）</h2>
+    <div id="map-large" class="geolonia" data-lazy-loading="off" style="width: 640px; height: 400px;"></div>
+  </div>
+
+  <div class="example">
+    <h2>中くらいの地図（既定文言・短縮版）</h2>
+    <div id="map-medium" class="geolonia" data-lazy-loading="off" style="width: 360px; height: 240px;"></div>
+  </div>
+
+  <div class="example">
+    <h2>小さい地図（既定文言・見出しのみ）</h2>
+    <div id="map-small" class="geolonia" data-lazy-loading="off" style="width: 220px; height: 130px;"></div>
+  </div>
+
+  <div class="example">
+    <h2>文言を差し替えた地図（data-error-message）</h2>
+    <div
+      id="map-custom"
+      class="geolonia"
+      data-lazy-loading="off"
+      style="width: 640px; height: 240px;"
+      data-error-message="地図を表示できませんでした。お手数ですが 0120-000-000 までご連絡ください。"
+    ></div>
+  </div>
+
+  <div class="example">
+    <h2>エラー表示を無効にした地図（data-error-message="off"）</h2>
+    <div
+      id="map-off"
+      class="geolonia"
+      data-lazy-loading="off"
+      style="width: 640px; height: 160px;"
+      data-error-message="off"
+    ></div>
+  </div>
+
+  <script src="../embed?geolonia-api-key=YOUR-API-KEY"></script>
+</body>
+</html>

--- a/e2e/webgl-error.spec.ts
+++ b/e2e/webgl-error.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test';
+import { TEST_URL } from './helper';
+
+/**
+ * WebGL が使えない端末での表示。
+ * フィクスチャ側で `getContext('webgl')` を null にして初期化を必ず失敗させている。
+ */
+test.describe('WebGL 初期化失敗時のエラー表示', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`${TEST_URL}/webgl-error.html`);
+    await page.waitForSelector('#map-large .geolonia__error-container');
+  });
+
+  test('広い地図では復旧手順まで表示する', async ({ page }) => {
+    const container = page.locator('#map-large');
+    await expect(
+      container.locator('.geolonia__error-message-title'),
+    ).toHaveText('地図を表示できませんでした');
+    await expect(
+      container.locator('.geolonia__error-message-lead'),
+    ).toBeVisible();
+    await expect(
+      container.locator('.geolonia__error-message-steps li'),
+    ).toHaveCount(4);
+    await expect(
+      container.locator('.geolonia__error-message-contact'),
+    ).toBeVisible();
+    await expect(
+      container.locator('.geolonia__error-message-brief'),
+    ).toBeHidden();
+  });
+
+  test('開発者向けの案内文を表示しない', async ({ page }) => {
+    await expect(page.locator('#map-large')).not.toContainText('開発者ツール');
+  });
+
+  test('中くらいの地図では短縮版に切り替わる', async ({ page }) => {
+    const container = page.locator('#map-medium');
+    await expect(
+      container.locator('.geolonia__error-message-title'),
+    ).toBeVisible();
+    await expect(
+      container.locator('.geolonia__error-message-brief'),
+    ).toBeVisible();
+    await expect(
+      container.locator('.geolonia__error-message-steps'),
+    ).toBeHidden();
+  });
+
+  test('小さい地図では見出しだけを表示する', async ({ page }) => {
+    const container = page.locator('#map-small');
+    await expect(
+      container.locator('.geolonia__error-message-title'),
+    ).toBeVisible();
+    await expect(
+      container.locator('.geolonia__error-message-brief'),
+    ).toBeHidden();
+    await expect(
+      container.locator('.geolonia__error-message-steps'),
+    ).toBeHidden();
+  });
+
+  test('エラー表示が地図コンテナからはみ出さない', async ({ page }) => {
+    for (const id of ['#map-large', '#map-medium', '#map-small']) {
+      const container = await page.locator(id).boundingBox();
+      const message = await page
+        .locator(`${id} .geolonia__error-message`)
+        .boundingBox();
+      expect(message.x).toBeGreaterThanOrEqual(container.x - 1);
+      expect(message.y).toBeGreaterThanOrEqual(container.y - 1);
+      expect(message.x + message.width).toBeLessThanOrEqual(
+        container.x + container.width + 1,
+      );
+      expect(message.y + message.height).toBeLessThanOrEqual(
+        container.y + container.height + 1,
+      );
+    }
+  });
+
+  test('data-error-message で文言を差し替えられる', async ({ page }) => {
+    const container = page.locator('#map-custom');
+    await expect(
+      container.locator('.geolonia__error-message-description'),
+    ).toHaveText(
+      '地図を表示できませんでした。お手数ですが 0120-000-000 までご連絡ください。',
+    );
+    await expect(
+      container.locator('.geolonia__error-message-steps'),
+    ).toHaveCount(0);
+  });
+
+  test('data-error-message="off" でエラー表示を無効にできる', async ({
+    page,
+  }) => {
+    await expect(
+      page.locator('#map-off .geolonia__error-container'),
+    ).toHaveCount(0);
+  });
+
+  test('初期化に失敗したらローディング表示を止める', async ({ page }) => {
+    for (const id of ['#map-large', '#map-off']) {
+      await expect(page.locator(`${id} .loading-geolonia-map`)).toHaveCount(0);
+    }
+  });
+});

--- a/src/lib/geolonia-map.ts
+++ b/src/lib/geolonia-map.ts
@@ -35,7 +35,14 @@ import {
   isGeoloniaTilesHost,
 } from './util';
 
-export type GeoloniaMapOptions = MapOptions & { interactive?: boolean };
+export type GeoloniaMapOptions = MapOptions & {
+  interactive?: boolean;
+  /**
+   * 地図の初期化に失敗したときに表示する文言。`'off'` を指定すると
+   * エラー表示自体を行わない。未指定のときは Embed 既定の案内を表示する。
+   */
+  errorMessage?: string;
+};
 
 type Container = HTMLElement & {
   geoloniaMap: GeoloniaMap;
@@ -189,7 +196,18 @@ export default class GeoloniaMap extends maplibregl.Map {
       // Generate Map
       super(options);
     } catch (error) {
-      handleErrorMode(container);
+      // 初期化に失敗した以上ローディングは終わらないので、先に消す。
+      // 消さないと `errorMessage: 'off'` のとき「読み込み中」のまま見えてしまう。
+      container.querySelector('.loading-geolonia-map')?.remove();
+      // `data-error-message` / コンストラクタの `errorMessage` で
+      // 文言の差し替えと表示の無効化（`'off'`）ができる。
+      handleErrorMode(container, {
+        message: String(
+          atts.errorMessage ||
+            (typeof params === 'object' && params.errorMessage) ||
+            '',
+        ),
+      });
       throw error;
     }
 

--- a/src/lib/geolonia-map.ts
+++ b/src/lib/geolonia-map.ts
@@ -38,10 +38,11 @@ import {
 export type GeoloniaMapOptions = MapOptions & {
   interactive?: boolean;
   /**
-   * 地図の初期化に失敗したときに表示する文言。`'off'` を指定すると
-   * エラー表示自体を行わない。未指定のときは Embed 既定の案内を表示する。
+   * 地図の初期化に失敗したときに表示する文言。`false` または `'off'` を
+   * 指定するとエラー表示自体を行わない。
+   * 未指定のときは Embed 既定の案内を表示する。
    */
-  errorMessage?: string;
+  errorMessage?: string | false;
 };
 
 type Container = HTMLElement & {
@@ -200,13 +201,14 @@ export default class GeoloniaMap extends maplibregl.Map {
       // 消さないと `errorMessage: 'off'` のとき「読み込み中」のまま見えてしまう。
       container.querySelector('.loading-geolonia-map')?.remove();
       // `data-error-message` / コンストラクタの `errorMessage` で
-      // 文言の差し替えと表示の無効化（`'off'`）ができる。
+      // 文言の差し替えと表示の無効化（`'off'` または `false`）ができる。
+      const attErrorMessage = atts.errorMessage
+        ? String(atts.errorMessage)
+        : undefined;
+      const optionErrorMessage =
+        typeof params === 'object' ? params.errorMessage : undefined;
       handleErrorMode(container, {
-        message: String(
-          atts.errorMessage ||
-            (typeof params === 'object' && params.errorMessage) ||
-            '',
-        ),
+        message: attErrorMessage ?? optionErrorMessage,
       });
       throw error;
     }

--- a/src/lib/parse-atts.test.ts
+++ b/src/lib/parse-atts.test.ts
@@ -51,6 +51,7 @@ describe('tests for parse Attributes', () => {
       apiUrl: 'https://api.geolonia.com/v1',
       stage: 'v1',
       loader: 'on',
+      errorMessage: '',
       minZoom: '',
       maxZoom: 20,
       '3d': '',

--- a/src/lib/parse-atts.ts
+++ b/src/lib/parse-atts.ts
@@ -59,6 +59,7 @@ export default (container, params: ParseAttsParams = {}): EmbedAttributes => {
     apiUrl: `https://api.geolonia.com/${keyring.stage}`,
     stage: keyring.stage,
     loader: 'on',
+    errorMessage: '',
     minZoom: '',
     maxZoom: 20,
     '3d': '',

--- a/src/lib/util.test.ts
+++ b/src/lib/util.test.ts
@@ -437,11 +437,13 @@ describe('handleErrorMode', () => {
     );
   });
 
-  it('off を指定すると何も描画しない', () => {
-    const container = createContainer();
-    handleErrorMode(container, { message: 'off' });
+  it('off / false を指定すると何も描画しない', () => {
+    for (const message of ['off', 'OFF', false] as const) {
+      const container = createContainer();
+      handleErrorMode(container, { message });
 
-    expect(container.querySelector('.geolonia__error-container')).toBeNull();
-    expect(container.children.length).toBe(0);
+      expect(container.querySelector('.geolonia__error-container')).toBeNull();
+      expect(container.children.length).toBe(0);
+    }
   });
 });

--- a/src/lib/util.test.ts
+++ b/src/lib/util.test.ts
@@ -14,6 +14,7 @@ import {
   parseSimpleVector,
   sanitizeDescription,
   loadImageCompatibility,
+  handleErrorMode,
 } from './util';
 
 const base = 'https://base.example.com/parent/';
@@ -360,5 +361,87 @@ describe('loadImageCompatibility', () => {
         resolve();
       });
     });
+  });
+});
+
+describe('handleErrorMode', () => {
+  const createContainer = () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    return container;
+  };
+
+  it('既定では行動につながる文言（見出し・手順・問い合わせ案内）を描画する', () => {
+    const container = createContainer();
+    handleErrorMode(container);
+
+    const errorContainer = container.querySelector(
+      '.geolonia__error-container',
+    );
+    expect(errorContainer).not.toBeNull();
+    expect(
+      errorContainer.querySelector('.geolonia__error-message-title')
+        .textContent,
+    ).toBe('地図を表示できませんでした');
+    // 手順は 4 つ（ブラウザ再起動 → 端末再起動 → 別ブラウザ → ドライバ更新）
+    expect(
+      errorContainer.querySelectorAll('.geolonia__error-message-steps li')
+        .length,
+    ).toBe(4);
+    expect(
+      errorContainer.querySelector('.geolonia__error-message-contact'),
+    ).not.toBeNull();
+  });
+
+  it('既定では狭いコンテナ向けの短縮文も同時に描画する（表示切替は CSS が担う）', () => {
+    const container = createContainer();
+    handleErrorMode(container);
+
+    expect(
+      container.querySelector('.geolonia__error-message-brief'),
+    ).not.toBeNull();
+  });
+
+  it('開発者向けの案内文（開発者ツール）を含まない', () => {
+    const container = createContainer();
+    handleErrorMode(container);
+
+    expect(container.textContent).not.toContain('開発者ツール');
+  });
+
+  it('data-error-message で文言を差し替えられる', () => {
+    const container = createContainer();
+    handleErrorMode(container, { message: '地図の表示に失敗しました。0120-000-000 までご連絡ください。' });
+
+    const description = container.querySelector(
+      '.geolonia__error-message-description',
+    );
+    expect(description.textContent).toBe(
+      '地図の表示に失敗しました。0120-000-000 までご連絡ください。',
+    );
+    // 既定の手順リストは描画しない
+    expect(
+      container.querySelector('.geolonia__error-message-steps'),
+    ).toBeNull();
+  });
+
+  it('差し替え文言の HTML はエスケープする', () => {
+    const container = createContainer();
+    handleErrorMode(container, {
+      message: '<img src=x onerror="alert(1)">お問い合わせください',
+    });
+
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.textContent).toContain(
+      '<img src=x onerror="alert(1)">お問い合わせください',
+    );
+  });
+
+  it('off を指定すると何も描画しない', () => {
+    const container = createContainer();
+    handleErrorMode(container, { message: 'off' });
+
+    expect(container.querySelector('.geolonia__error-container')).toBeNull();
+    expect(container.children.length).toBe(0);
   });
 });

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -380,15 +380,20 @@ export const handleRestrictedMode = (map) => {
  * 復旧手順を描画する。手順を書き切った版と 1 行の短縮版の両方を DOM に入れておき、
  * どちらを見せるかは地図コンテナの広さに応じて CSS（コンテナクエリ）が決める。
  * 消費側で文言を差し替えたい場合は `data-error-message` に文字列を、
- * エラー表示自体を止めたい場合は `data-error-message="off"` を指定する。
+ * エラー表示自体を止めたい場合は `data-error-message="off"`（プログラム API では
+ * `errorMessage: false`）を指定する。
  *
  * @param container 地図コンテナ
- * @param options `message` に差し替え文言、または `'off'`（表示しない）
+ * @param options `message` に差し替え文言、`false` / `'off'` で表示しない
  */
 export const handleErrorMode = (
   container: HTMLElement,
-  options: { message?: string } = {},
+  options: { message?: string | false } = {},
 ): void => {
+  if (options.message === false) {
+    return;
+  }
+
   const message = (options.message ?? '').trim();
 
   if (message.toLowerCase() === 'off') {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -373,19 +373,83 @@ export const handleRestrictedMode = (map) => {
   }
 };
 
-export const handleErrorMode = (container) => {
+/**
+ * 地図の初期化に失敗したときのエラー表示。
+ *
+ * 既定では「WebGL が使えない状態かもしれない」という原因と、利用者が自分で試せる
+ * 復旧手順を描画する。手順を書き切った版と 1 行の短縮版の両方を DOM に入れておき、
+ * どちらを見せるかは地図コンテナの広さに応じて CSS（コンテナクエリ）が決める。
+ * 消費側で文言を差し替えたい場合は `data-error-message` に文字列を、
+ * エラー表示自体を止めたい場合は `data-error-message="off"` を指定する。
+ *
+ * @param container 地図コンテナ
+ * @param options `message` に差し替え文言、または `'off'`（表示しない）
+ */
+export const handleErrorMode = (
+  container: HTMLElement,
+  options: { message?: string } = {},
+): void => {
+  const message = (options.message ?? '').trim();
+
+  if (message.toLowerCase() === 'off') {
+    return;
+  }
+
   const errorContainer = document.createElement('div');
   errorContainer.classList.add('geolonia__error-container');
 
   const div = document.createElement('div');
-
-  const h1 = document.createElement('h2');
-  h1.textContent = 'Geolonia Maps';
-  div.appendChild(h1);
-
   div.classList.add('geolonia__error-message');
-  div.innerHTML +=
-    '<div class="geolonia__error-message-description">地図の初期化に失敗しました。管理者にお問い合わせ下さい。開発者の方は開発者ツールでエラー詳細をご確認下さい。</div>';
+  div.setAttribute('role', 'alert');
+
+  const description = document.createElement('div');
+  description.classList.add('geolonia__error-message-description');
+
+  if (message) {
+    // 消費側が指定した文言。HTML は解釈せずテキストとして描画する。
+    description.textContent = message;
+    div.appendChild(description);
+  } else {
+    const title = document.createElement('h2');
+    title.classList.add('geolonia__error-message-title');
+    title.textContent = '地図を表示できませんでした';
+    div.appendChild(title);
+
+    const lead = document.createElement('p');
+    lead.classList.add('geolonia__error-message-lead');
+    lead.textContent =
+      'お使いの環境で地図の描画機能（WebGL）が利用できない状態になっている可能性があります。次の順にお試しください。';
+    description.appendChild(lead);
+
+    const steps = document.createElement('ol');
+    steps.classList.add('geolonia__error-message-steps');
+    for (const step of [
+      'ブラウザをすべて閉じて、開き直す',
+      'パソコンやスマートフォンを再起動する',
+      '別のブラウザで開く',
+      'パソコンの場合は、グラフィックドライバを更新する',
+    ]) {
+      const li = document.createElement('li');
+      li.textContent = step;
+      steps.appendChild(li);
+    }
+    description.appendChild(steps);
+
+    const contact = document.createElement('p');
+    contact.classList.add('geolonia__error-message-contact');
+    contact.textContent =
+      '解決しない場合は、このサイトの窓口までご連絡ください。';
+    description.appendChild(contact);
+
+    // 手順を書き切れない狭いコンテナ向け。表示の切り替えは CSS が行う。
+    const brief = document.createElement('p');
+    brief.classList.add('geolonia__error-message-brief');
+    brief.textContent =
+      'ブラウザや端末を再起動すると解消する場合があります。';
+    description.appendChild(brief);
+
+    div.appendChild(description);
+  }
 
   errorContainer.appendChild(div);
   container.appendChild(errorContainer);

--- a/src/style.css
+++ b/src/style.css
@@ -111,6 +111,11 @@
 }
 
 /* Style for error message */
+/*
+ * 文言は「手順を書き切った版」と「短縮版」の両方が DOM にあり、
+ * どちらを見せるかは地図コンテナの広さで切り替える。
+ * コンテナクエリ非対応のブラウザでは手順を書き切った版が出る（情報が減る側に倒さない）。
+ */
 .geolonia__error-container {
   display: flex;
   justify-content: center;
@@ -120,22 +125,82 @@
   background-color: #dedede;
   z-index: 9999;
   position: absolute;
+  container-type: size;
+  container-name: geolonia-error;
 }
 
 .geolonia__error-message {
-  max-width: 300px;
+  max-width: 360px;
+  max-height: calc(100% - 20px);
+  overflow: auto;
   background-color: #ffffff;
   margin: 10px;
   padding: 0.75rem 1.25rem;
   border-radius: 6px;
-  position: absolute;
   z-index: 99999;
   word-wrap: break-word;
-  box-shadow: 0 4px 10px #0000001a
+  box-shadow: 0 4px 10px #0000001a;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #333333;
+}
+
+.geolonia__error-message-title {
+  margin: 0 0 0.5em;
+  font-size: 16px;
+  line-height: 1.4;
 }
 
 .geolonia__error-message-description {
-  margin: 15px 0;
+  margin: 0;
+}
+
+.geolonia__error-message-lead {
+  margin: 0 0 0.5em;
+}
+
+.geolonia__error-message-steps {
+  margin: 0 0 0.5em;
+  padding-left: 1.4em;
+}
+
+.geolonia__error-message-contact {
+  margin: 0;
+}
+
+.geolonia__error-message-brief {
+  display: none;
+  margin: 0;
+}
+
+/* 中くらいの地図：手順リストは収まらないので 1 行の短縮版に切り替える */
+@container geolonia-error ((max-width: 379px) or (max-height: 259px)) {
+  .geolonia__error-message-lead,
+  .geolonia__error-message-steps,
+  .geolonia__error-message-contact {
+    display: none;
+  }
+
+  .geolonia__error-message-brief {
+    display: block;
+  }
+}
+
+/* 小さい地図：見出しだけにする */
+@container geolonia-error ((max-width: 239px) or (max-height: 139px)) {
+  .geolonia__error-message {
+    padding: 0.5rem 0.75rem;
+    font-size: 13px;
+  }
+
+  .geolonia__error-message-title {
+    margin: 0;
+    font-size: 14px;
+  }
+
+  .geolonia__error-message-brief {
+    display: none;
+  }
 }
 
 /* CSS for Attribution */

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,12 @@ export type EmbedAttributes = {
   key: string;
   apiUrl: string;
   loader: string;
+  /**
+   * `data-error-message`：地図の初期化に失敗したときの表示。
+   * 文字列を指定するとその文言に差し替え、`'off'` を指定するとエラー表示自体を行わない。
+   * 未指定のときは Embed 既定の案内（復旧手順つき）を表示する。
+   */
+  errorMessage: string;
   minZoom: string | number;
   maxZoom: string | number;
   '3d': string;


### PR DESCRIPTION
Closes #515

## 何を変えたか

地図の初期化に失敗したときの表示を、利用者が自分で復旧を試せる内容に変更しました。あわせて、文言を消費側で差し替え・無効化できる `data-error-message` を追加しています。

### 既定の文言

変更前は「地図の初期化に失敗しました。管理者にお問い合わせ下さい。開発者の方は開発者ツールでエラー詳細をご確認下さい。」の一文のみでした。変更後は次の内容です。

- 見出し: 地図を表示できませんでした
- 原因: お使いの環境で地図の描画機能（WebGL）が利用できない状態になっている可能性があります
- 手順: ブラウザを開き直す / 端末を再起動する / 別のブラウザで開く / グラフィックドライバを更新する
- それでも直らないときの窓口案内

開発者向けの一文は削除しました。

### 地図の広さに応じた出し分け

地図コンテナは小さいことも多いため、コンテナクエリで3段階に切り替えます。

| コンテナの広さ | 表示 |
| --- | --- |
| 380x260 以上 | 見出し + 原因 + 手順4つ + 窓口案内 |
| それ未満 | 見出し + 「ブラウザや端末を再起動すると解消する場合があります。」 |
| 240x140 未満 | 見出しのみ |

3種類とも DOM には入れておき、表示の切り替えは CSS が行います。コンテナクエリ非対応のブラウザでは手順つきの全文が出ます（情報が減る側に倒さない方針）。収まらない場合はメッセージ内でスクロールします。

### 差し替え・無効化

```html
<!-- 文言を差し替える -->
<div class="geolonia" data-error-message="地図を表示できませんでした。0120-000-000 までご連絡ください。"></div>

<!-- エラー表示自体を行わない -->
<div class="geolonia" data-error-message="off"></div>
```

プログラム API では `new GeoloniaMap({ container, errorMessage: '...' })` として同じ指定ができます。値は HTML として解釈せずテキストとして描画します。

### ローディング表示の停止

初期化に失敗してもローディングアニメーションが止まらず、`off` を指定すると「読み込み中のまま」に見える状態だったため、失敗時に必ず消すようにしました。

### CI

保守ブランチでも build が回るよう、`build.yml` のトリガに `maintenance/**` を追加しました。

## 動作確認

- unit: 57件 green（`handleErrorMode` の6ケースを追加）
- e2e: WebGL を無効化したフィクスチャで8ケース追加。chromium 16件・webkit 8件 green
- `npm run build` 成功、lint はこの PR に関係しない既存の警告1件のみ

E2E は `docs/e2e/webgl-error.html` で `getContext('webgl')` を null にして初期化を必ず失敗させています。ローカルで `npm start` して同ページを開けば、4種類の見え方をそのまま確認できます。